### PR TITLE
Add Valid Topics Config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/spf13/viper"
 )
 
@@ -14,6 +16,7 @@ type IngressConfig struct {
 	KafkaGroupID         string
 	KafkaAvailableTopic  string
 	KafkaValidationTopic string
+	ValidTopics          []string
 	Port                 int
 }
 
@@ -29,6 +32,7 @@ func Get() *IngressConfig {
 	options.SetDefault("KafkaGroupID", "ingress")
 	options.SetDefault("KafkaAvailableTopic", "platform.upload.available")
 	options.SetDefault("KafkaValidationTopic", "platform.upload.validation")
+	options.SetDefault("ValidTopics", "unit")
 	options.SetEnvPrefix("INGRESS")
 	options.AutomaticEnv()
 
@@ -41,6 +45,7 @@ func Get() *IngressConfig {
 		KafkaGroupID:         options.GetString("KafkaGroupID"),
 		KafkaAvailableTopic:  options.GetString("KafkaAvailableTopic"),
 		KafkaValidationTopic: options.GetString("KafkaValidationTopic"),
+		ValidTopics:          strings.Split(options.GetString("ValidTopics"), ","),
 		Port:                 options.GetInt("Port"),
 	}
 }

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -17,12 +17,25 @@ import (
 
 var contentTypePat = regexp.MustCompile(`application/vnd\.redhat\.(\w+)\.(\w+)`)
 
+func isValidTopic(service string) bool {
+	list := config.Get().ValidTopics
+	for _, validService := range list {
+		if validService == service {
+			return true
+		}
+	}
+	return false
+}
+
 func validate(contentType string) (*TopicDescriptor, error) {
 	// look the content type up in a static map
 	// else parse it
 	m := contentTypePat.FindStringSubmatch(contentType)
 	if m == nil {
 		return nil, errors.New("Failed to match on Content-Type: " + contentType)
+	}
+	if isValidTopic(m[1]) == false {
+		return nil, errors.New("Invalid Service: " + m[1])
 	}
 	return &TopicDescriptor{
 		Service:  m[1],

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -198,5 +198,14 @@ var _ = Describe("Upload", func() {
 				Expect(res.Validation).To(Equal("success"))
 			})
 		})
+
+		Context("with invalid service name", func() {
+			It("should return 415", func() {
+				boiler(http.StatusUnsupportedMediaType, &FilePart{
+					Name:        "file",
+					Content:     "testing",
+					ContentType: "application/vnd.redhat.failed.test"})
+			})
+		})
 	})
 })


### PR DESCRIPTION
We need to be able to check that a kafka topic exists before submitting
messages to it. This will allow us to configure a valid topics list that
can be checked against