### PR TITLE
Remove /api/ingress/v1/metrics endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,6 @@ func main() {
 	r.Route("/api/ingress/v1", func(r chi.Router) {
 		r.Get("/", lubDub)
 		r.Post("/upload", upload.NewHandler(p))
-		r.Handle("/metrics", promhttp.Handler())
 	})
 	r.Get("/", lubDub)
 	r.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
We don't need this to be exposed on this endpoint. Just keeping it to
/metrics will be fine since we never expect anything outside of the
cluster to hit it.