### PR TITLE
Get the real request_ID

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -13,6 +13,15 @@ import (
 	"go.uber.org/zap"
 )
 
+func getRequestID(h, fallback string) string {
+
+	reqID := h
+	if h == "" {
+		reqID = fallback
+	}
+	return reqID
+}
+
 // NewHandler returns a http handler configured with a Pipeline
 func NewHandler(p *pipeline.Pipeline) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -38,7 +47,8 @@ func NewHandler(p *pipeline.Pipeline) http.HandlerFunc {
 
 		b64Identity := r.Header.Get("x-rh-identity")
 
-		reqID := middleware.GetReqID(r.Context())
+		reqID := getRequestID(r.Header.Get("x-rh-insights-request-id"),
+			middleware.GetReqID(r.Context()))
 
 		stageInput := &stage.Input{
 			Payload: file,


### PR DESCRIPTION
We need to be able to use the request ID that comes from 3scale. This
will use that id if it's available, but will default to the context
request id from chi if we don't have one.