### PR TITLE
Fix print of requestID twice

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -80,7 +80,6 @@ func NewHandler(p *pipeline.Pipeline) http.HandlerFunc {
 
 		go p.Submit(stageInput, vr)
 
-		w.Header().Set("X-Request-Id", reqID)
 		w.WriteHeader(http.StatusAccepted)
 	}
 }


### PR DESCRIPTION
We were sending back two headers with the same request_id