### PR TITLE
Update version endpoint location

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,9 +106,9 @@ func main() {
 			r.Get("/", lubDub)
 			r.Post("/upload", upload.NewHandler(p))
 		}
+		r.Get("/version", version.GetVersion)
 	})
 	r.Get("/", lubDub)
-	r.Get("/version", version.GetVersion)
 	r.Handle("/metrics", promhttp.Handler())
 	l.Log.Info("Starting service", zap.Int("port", cfg.Port))
 

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func GetServer() (*httptest.ResponseRecorder, *http.Request) {
-	req, _ := http.NewRequest("GET", "/version", nil)
+	req, _ := http.NewRequest("GET", "/api/ingress/v1/version", nil)
 	rr := httptest.NewRecorder()
 
 	return rr, req


### PR DESCRIPTION
Need to move this to be located under `api/ingress/v1` to match the old ingress service