### PR TITLE
Set Version endpoint env

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,9 @@ func Get() *IngressConfig {
 	options.SetDefault("InventoryURL", "http://inventory:8080/api/inventory/v1/hosts")
 	options.SetEnvPrefix("INGRESS")
 	options.AutomaticEnv()
+	commit := viper.New()
+	commit.SetDefault("Openshift_Build_Commit", "notrunninginopenshift")
+	commit.AutomaticEnv()
 
 	return &IngressConfig{
 		MaxSize:                     options.GetInt("MaxSize"),
@@ -62,7 +65,7 @@ func Get() *IngressConfig {
 		KafkaValidationTopic:        options.GetString("KafkaValidationTopic"),
 		ValidTopics:                 strings.Split(options.GetString("ValidTopics"), ","),
 		Port:                        options.GetInt("Port"),
-		OpenshiftBuildCommit:        options.GetString("OpenshiftBuildCommit"),
+		OpenshiftBuildCommit:        commit.GetString("Openshift_Build_Commit"),
 		Version:                     "1.0.0",
 		Simulate:                    options.GetBool("Simulate"),
 		SimulationStageDelay:        options.GetDuration("SimulationStageDelay"),


### PR DESCRIPTION
The prefix we're adding in the standard environment fetch won't work
with Openshift_Build_Commit. Needed to add a second viper instance that
doesn't preprend `INGRESS_` to the var.