### PR TITLE
Add request_id field to existing log messages

### DIFF
--- a/announcers/kafka.go
+++ b/announcers/kafka.go
@@ -27,7 +27,7 @@ func NewKafkaAnnouncer(cfg *queue.ProducerConfig) *Kafka {
 func (k *Kafka) Announce(vr *validators.Response) {
 	data, err := json.Marshal(vr)
 	if err != nil {
-		l.Log.Error("failed to marshal json", zap.Error(err))
+		l.Log.Error("failed to marshal json", zap.Error(err), zap.String("request_id", vr.RequestID))
 		return
 	}
 	k.In <- data

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -25,9 +25,6 @@ func GetFile(r *http.Request) (multipart.File, *multipart.FileHeader, error) {
 	if err == nil {
 		return file, fileHeader, nil
 	}
-	if err != nil {
-		l.Log.Error("Unable to find `file` or `upload` parts", zap.Error(err))
-	}
 	return nil, nil, err
 }
 


### PR DESCRIPTION
We need the request_id to show up in the logs for indexing. This is
needed particuarly when troubleshooting failed uploads