### PR TITLE
Shorten the valid topics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ func Get() *IngressConfig {
 	options.SetDefault("KafkaAvailableTopic", "platform.upload.available")
 	options.SetDefault("KafkaValidationTopic", "platform.upload.validation")
 	options.SetDefault("KafkaTrackerTopic", "platform.payload-status")
-	options.SetDefault("ValidTopics", "platform.upload.unit")
+	options.SetDefault("ValidTopics", "unit")
 	options.SetDefault("OpenshiftBuildCommit", "notrunninginopenshift")
 	options.SetDefault("Simulate", false)
 	options.SetDefault("SimulationStageDelay", 100)

--- a/validators/kafka/kafka.go
+++ b/validators/kafka/kafka.go
@@ -16,8 +16,8 @@ var tdMapping map[string]string
 
 func init() {
 	tdMapping = make(map[string]string)
-	tdMapping["unit2"] = "platform.upload.unit"
-	tdMapping["openshift"] = "platform.upload.buckit"
+	tdMapping["unit2"] = "unit"
+	tdMapping["openshift"] = "buckit"
 }
 
 // New constructs and initializes a new Kafka Validator
@@ -130,5 +130,5 @@ func serviceToTopic(service string) string {
 	if topic != "" {
 		return topic
 	}
-	return fmt.Sprintf("platform.upload.%s", service)
+	return fmt.Sprintf("%s", service)
 }


### PR DESCRIPTION
We really only need the third stanza of a valid topic. Since we're
manually inserting these with an env variable, we can drop the
`platform.upload` portion of the valid topics. This leaves us with just
a name of the service we expect.

We need to coordinate this merge because I'll need to update the environment variable.