### PR TITLE
Fix metadata bug

### DIFF
--- a/interactions/inventory/inventory.go
+++ b/interactions/inventory/inventory.go
@@ -53,7 +53,9 @@ func CreatePost(vr *validators.Request) ([]byte, error) {
 	}
 
 	postBody.Account = vr.Account
-	postBody.Facts[0].Namespace = vr.UserAgent
+	if len(postBody.Facts) > 0 {
+		postBody.Facts[0].Namespace = vr.UserAgent
+	}
 
 	post, _ := json.Marshal([]Metadata{postBody})
 

--- a/interactions/inventory/inventory.go
+++ b/interactions/inventory/inventory.go
@@ -53,6 +53,7 @@ func CreatePost(vr *validators.Request) ([]byte, error) {
 	}
 
 	postBody.Account = vr.Account
+	postBody.Facts[0].Namespace = vr.UserAgent
 
 	post, _ := json.Marshal([]Metadata{postBody})
 

--- a/interactions/inventory/types.go
+++ b/interactions/inventory/types.go
@@ -12,6 +12,11 @@ type Response struct {
 	} `json:"data"`
 }
 
+type facts struct {
+	Namespace string                 `json:"namespace"`
+	Facts     map[string]interface{} `json:"facts"`
+}
+
 // Metadata is the expected data from a client
 type Metadata struct {
 	IPAddresses  []string `json:"ip_addresses,omitempty"`
@@ -21,6 +26,7 @@ type Metadata struct {
 	SubManID     string   `json:"subscription_manager_id,omitempty"`
 	MacAddresses []string `json:"mac_addresses,omitempty"`
 	FQDN         string   `json:"fqdn,omitempty"`
+	Facts        []facts  `json:"facts,omitempty"`
 }
 
 // Inventory can return an inventory ID

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -76,6 +76,7 @@ func NewHandler(p *pipeline.Pipeline) http.HandlerFunc {
 			Category:    serviceDescriptor.Category,
 			B64Identity: b64Identity,
 			Metadata:    metadata,
+			UserAgent:   userAgent,
 		}
 
 		if config.Get().Auth == true {

--- a/validators/types.go
+++ b/validators/types.go
@@ -17,6 +17,7 @@ type Request struct {
 	URL         string    `json:"url"`
 	ID          string    `json:"id,omitempty"`
 	B64Identity string    `json:"b64_identity"`
+	UserAgent   string
 	Timestamp   time.Time `json:"timestamp"`
 }
 


### PR DESCRIPTION
We were't getting "extra" facts due to not having a type to handle them in our metadata struct. I added that along with tests.

In addition, we have to have a namespace value in the facts dict. Pulling it from the useragent.

RHCLOUD-1674