### PR TITLE
Add handoff response from validators

### DIFF
--- a/validators/kafka/kafka.go
+++ b/validators/kafka/kafka.go
@@ -88,6 +88,8 @@ func (kv *Validator) RouteResponse(response *validators.Response) {
 		kv.ValidChan <- response
 	case "failure":
 		kv.InvalidChan <- response
+	case "handoff":
+		l.Log.Info("Validation handed off", zap.String("request_id", response.RequestID), zap.String("account", response.Account))
 	default:
 		l.Log.Error("Invalid validation in response", zap.String("response.validation", response.Validation))
 		return

--- a/validators/kafka/kafka_test.go
+++ b/validators/kafka/kafka_test.go
@@ -60,6 +60,15 @@ var _ = Describe("Kafka", func() {
 				Expect(wait(kv.ValidChan)).To(BeFalse())
 			})
 		})
+		Context("with validation set to 'handoff'", func() {
+			It("should not forward to any channel", func() {
+				go kv.RouteResponse(&validators.Response{
+					Validation: "handoff",
+				})
+				Expect(wait(kv.InvalidChan)).To(BeFalse())
+				Expect(wait(kv.ValidChan)).To(BeFalse())
+			})
+		})
 	})
 
 	Describe("Validating a service", func() {


### PR DESCRIPTION
We only have one instance currently where we expect a handoff return. We
need to cover that and at least log that the message was handed off.