### PR TITLE
Fix status time

### DIFF
--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -28,7 +28,7 @@ func (p *Pipeline) Submit(in *stage.Input, vr *validators.Request) {
 		RequestID: vr.RequestID,
 		Status:    "processing",
 		StatusMsg: "Sent to validation service",
-		Date:      time.Now(),
+		Date:      time.Now().UTC(),
 	}
 	p.Tracker.Status(ps)
 	p.Validator.Validate(vr)
@@ -54,13 +54,13 @@ func (p *Pipeline) Tick(ctx context.Context) bool {
 			Status:      "validated",
 			StatusMsg:   "Payload validated by service",
 			InventoryID: ev.ID,
-			Date:        time.Now(),
+			Date:        time.Now().UTC(),
 		}
 		p.Tracker.Status(ps)
 		p.Announcer.Announce(ev)
 		ps.Status = "announced"
 		ps.StatusMsg = "Announced to platform"
-		ps.Date = time.Now()
+		ps.Date = time.Now().UTC()
 		p.Tracker.Status(ps)
 	case iev, ok := <-p.InvalidChan:
 		if !ok {
@@ -72,7 +72,7 @@ func (p *Pipeline) Tick(ctx context.Context) bool {
 			RequestID: iev.RequestID,
 			Status:    "Rejected",
 			StatusMsg: "Payload not valid. rejecting",
-			Date:      time.Now(),
+			Date:      time.Now().UTC(),
 		}
 		p.Tracker.Status(ps)
 		p.Stager.Reject(iev.RequestID)

--- a/validators/types.go
+++ b/validators/types.go
@@ -40,8 +40,8 @@ type Status struct {
 	Source      string    `json:"source,omitempty"`
 	Account     string    `json:"account"`
 	RequestID   string    `json:"request_id"`
-	InventoryID string    `json:"inventory_id"`
-	SystemID    string    `json:"system_id"`
+	InventoryID string    `json:"inventory_id,omitempty"`
+	SystemID    string    `json:"system_id,omitempty"`
 	Status      string    `json:"status"`
 	StatusMsg   string    `json:"status_msg"`
 	Date        time.Time `json:"date"`


### PR DESCRIPTION
Payload tracker is currently not accepting our status messages due to us
using local timezone. Updating to use UTC so that the times match up.

Also took the opportunity to use omitempty on a couple json fields that
we may not have.

Signed-off-by: Stephen Adams <tsadams@gmail.com>