### PR TITLE
Fix issue regarding metadata reading

### DIFF
--- a/interactions/inventory/inventory.go
+++ b/interactions/inventory/inventory.go
@@ -13,18 +13,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// GetJSON decodes the incoming metadata from an upload
-func GetJSON(metadata []byte) (Metadata, error) {
-
-	var dj Metadata
-	err := json.Unmarshal(metadata, &dj)
-	if err != nil {
-		return Metadata{}, err
-	}
-
-	return dj, nil
-}
-
 // Post JSON data to given URL
 func Post(identity string, data []byte, url string) (*http.Response, error) {
 
@@ -46,14 +34,11 @@ func Post(identity string, data []byte, url string) (*http.Response, error) {
 // CreatePost puts together the post to be sent to inventory
 func CreatePost(vr *validators.Request) ([]byte, error) {
 
-	postBody, err := GetJSON(vr.Metadata)
+	vr.Metadata.Account = vr.Account
+	post, err := json.Marshal([]validators.Metadata{vr.Metadata})
 	if err != nil {
-		return nil, err
+		l.Log.Error("Unable to create inventory post JSON", zap.Error(err), zap.String("request_id", vr.RequestID))
 	}
-
-	postBody.Account = vr.Account
-
-	post, _ := json.Marshal([]Metadata{postBody})
 
 	return post, nil
 }

--- a/interactions/inventory/types.go
+++ b/interactions/inventory/types.go
@@ -12,17 +12,6 @@ type Response struct {
 	} `json:"data"`
 }
 
-// Metadata is the expected data from a client
-type Metadata struct {
-	IPAddresses  []string `json:"ip_addresses,omitempty"`
-	Account      string   `json:"account,omitempty"`
-	InsightsID   string   `json:"insights_id,omitempty"`
-	MachineID    string   `json:"machine_id,omitempty"`
-	SubManID     string   `json:"subscription_manager_id,omitempty"`
-	MacAddresses []string `json:"mac_addresses,omitempty"`
-	FQDN         string   `json:"fqdn,omitempty"`
-}
-
 // Inventory can return an inventory ID
 type Inventory interface {
 	GetID(vr *validators.Request) (string, error)

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Upload", func() {
 					},
 					&FilePart{
 						Name:        "metadata",
-						Content:     "md",
+						Content:     `{"account": "012345"}`,
 						ContentType: "text/plain",
 					},
 				)
@@ -147,7 +147,7 @@ var _ = Describe("Upload", func() {
 				Expect(in).To(Not(BeNil()))
 				vin := validator.In
 				Expect(vin).To(Not(BeNil()))
-				Expect(string(vin.Metadata)).To(Equal("md"))
+				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345"}))
 			})
 		})
 

--- a/validators/types.go
+++ b/validators/types.go
@@ -8,7 +8,7 @@ import (
 type Request struct {
 	Account     string    `json:"account"`
 	Category    string    `json:"category"`
-	Metadata    []byte    `json:"metadata"`
+	Metadata    Metadata  `json:"metadata"`
 	RequestID   string    `json:"request_id"`
 	Principal   string    `json:"principal"`
 	Service     string    `json:"service"`
@@ -45,6 +45,17 @@ type Status struct {
 	Status      string    `json:"status"`
 	StatusMsg   string    `json:"status_msg"`
 	Date        time.Time `json:"date"`
+}
+
+// Metadata is the expected data from a client
+type Metadata struct {
+	IPAddresses  []string `json:"ip_addresses,omitempty"`
+	Account      string   `json:"account,omitempty"`
+	InsightsID   string   `json:"insights_id,omitempty"`
+	MachineID    string   `json:"machine_id,omitempty"`
+	SubManID     string   `json:"subscription_manager_id,omitempty"`
+	MacAddresses []string `json:"mac_addresses,omitempty"`
+	FQDN         string   `json:"fqdn,omitempty"`
 }
 
 // ServiceDescriptor is used to select a message topic


### PR DESCRIPTION
Needed to use an io.Reader to keep metadata from being changed to a
base64 encoded string

Signed-off-by: Stephen Adams <tsadams@gmail.com>