### PR TITLE
Fix memory leak in response body

### DIFF
--- a/interactions/inventory/inventory.go
+++ b/interactions/inventory/inventory.go
@@ -60,6 +60,7 @@ func (h *HTTP) GetID(vr *validators.Request) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	r := &Response{}
 	if resp.StatusCode == 207 {


### PR DESCRIPTION
We need to close the response body from inventory. If we do not
explicitly close it, the connection can remain open and be a resource
leak.

Signed-off-by: Stephen Adams <tsadams@gmail.com>