### PR TITLE
Fix content type

### DIFF
--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -219,6 +219,16 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
+		Context("with alternate legacy content type", func() {
+			It("should validate and be processed", func() {
+				boiler(http.StatusAccepted, &FilePart{
+					Name:        "file",
+					Content:     "testing",
+					ContentType: "application/gzip",
+				})
+			})
+		})
+
 		Context("with invalid service name", func() {
 			It("should return 415", func() {
 				boiler(http.StatusUnsupportedMediaType, &FilePart{

--- a/upload/validation.go
+++ b/upload/validation.go
@@ -1,26 +1,34 @@
 package upload
 
 import (
-	"regexp"
 	"errors"
+	"regexp"
+
 	"github.com/redhatinsights/insights-ingress-go/validators"
 )
 
 var contentTypePat = regexp.MustCompile(`application/vnd\.redhat\.([a-z0-9-]+)\.([a-z0-9-]+).*`)
 
 func getServiceDescriptor(contentType string) (*validators.ServiceDescriptor, error) {
-	if contentType == "application/x-gzip; charset=binary" {
+	switch ctype := contentType; ctype {
+	case "application/x-gzip; charset=binary":
 		return &validators.ServiceDescriptor{
-			Service: "advisor",
+			Service:  "advisor",
 			Category: "upload",
 		}, nil
+	case "application/gzip":
+		return &validators.ServiceDescriptor{
+			Service:  "advisor",
+			Category: "upload",
+		}, nil
+	default:
+		m := contentTypePat.FindStringSubmatch(ctype)
+		if m == nil {
+			return nil, errors.New("Failed to match on Content-Type: " + ctype)
+		}
+		return &validators.ServiceDescriptor{
+			Service:  m[1],
+			Category: m[2],
+		}, nil
 	}
-	m := contentTypePat.FindStringSubmatch(contentType)
-	if m == nil {
-		return nil, errors.New("Failed to match on Content-Type: " + contentType)
-	}
-	return &validators.ServiceDescriptor{
-		Service:  m[1],
-		Category: m[2],
-	}, nil
 }


### PR DESCRIPTION
We are getting `application/gzip` from some legacy payloads. We should accept these when they come in and send them to advisor.