### PR TITLE
Adding a channel buffer to validators

### DIFF
--- a/validators/kafka/kafka.go
+++ b/validators/kafka/kafka.go
@@ -108,7 +108,7 @@ func (kv *Validator) Validate(vr *validators.Request) {
 }
 
 func (kv *Validator) addProducer(topic string) {
-	ch := make(chan []byte)
+	ch := make(chan []byte, 100)
 	go queue.Producer(ch, &queue.ProducerConfig{
 		Brokers: kv.KafkaBrokers,
 		Topic:   topic,


### PR DESCRIPTION
This change introduces a buffer of 100 messages to each producer queue.
Since the kafka client only flushes the internal batch queue when 100
messages have been buffered OR the batch is 1 second old AND we are
currently using a synchronous channel the effect is most calls to
validation wait up to one second to send.

This causes, possibly many, goroutines to stack up in memory waiting for
their turn to return from Validate and be collected.