### PR TITLE
Need to send back a 413 when the file is over 100M

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // IngressConfig represents the runtime configuration
 type IngressConfig struct {
-	MaxSize              int
+	MaxSize              int64
 	StageBucket          string
 	RejectBucket         string
 	Auth                 bool
@@ -53,7 +53,7 @@ func Get() *IngressConfig {
 	commit.AutomaticEnv()
 
 	return &IngressConfig{
-		MaxSize:              options.GetInt("MaxSize"),
+		MaxSize:              options.GetInt64("MaxSize"),
 		StageBucket:          options.GetString("StageBucket"),
 		RejectBucket:         options.GetString("RejectBucket"),
 		Auth:                 options.GetBool("Auth"),

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -69,6 +69,12 @@ func NewHandler(p *pipeline.Pipeline) http.HandlerFunc {
 			return
 		}
 
+		if fileHeader.Size > config.Get().MaxSize {
+			l.Log.Info("File exceeds maximum file size for upload", zap.Int64("size", fileHeader.Size), zap.String("request_id", reqID))
+			w.WriteHeader(413)
+			return
+		}
+
 		if err := p.Validator.ValidateService(serviceDescriptor); err != nil {
 			l.Log.Info("Unrecognized service", zap.Error(err), zap.String("request_id", reqID))
 			w.WriteHeader(http.StatusUnsupportedMediaType)


### PR DESCRIPTION
We had established a max file size but we didn't use it anywhere. This
should send back a 413 if we exceed the max size.