### PR TITLE
Increase max size to 100MB

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ type IngressConfig struct {
 // Get returns an initialized IngressConfig
 func Get() *IngressConfig {
 	options := viper.New()
-	options.SetDefault("MaxSize", 10*1024*1024)
+	options.SetDefault("MaxSize", 100*1024*1024)
 	options.SetDefault("Port", 3000)
 	options.SetDefault("StageBucket", "available")
 	options.SetDefault("RejectBucket", "rejected")


### PR DESCRIPTION
Advisor can accept 100MB files so ingress should set the ceiling to this
amount.

Signed-off-by: Stephen Adams <tsadams@gmail.com>