### PR TITLE
do not swallow errors on upload failures

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -3,6 +3,7 @@ package upload
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
@@ -21,16 +22,15 @@ import (
 
 // GetFile verifies that the proper upload field is in place and returns the file
 func GetFile(r *http.Request) (multipart.File, *multipart.FileHeader, error) {
-	var err error
-	file, fileHeader, err := r.FormFile("file")
-	if err == nil {
+	file, fileHeader, fileErr := r.FormFile("file")
+	if fileErr == nil {
 		return file, fileHeader, nil
 	}
-	file, fileHeader, err = r.FormFile("upload")
-	if err == nil {
+	file, fileHeader, uploadErr := r.FormFile("upload")
+	if uploadErr == nil {
 		return file, fileHeader, nil
 	}
-	return nil, nil, err
+	return nil, nil, fmt.Errorf("file: %v, upload: %v", fileErr, uploadErr)
 }
 
 func readMetadataPart(r *http.Request) ([]byte, error) {


### PR DESCRIPTION
Return both file and upload errors (we use file method, it failed, but we get wrong error as we tried upload next). 