### PR TITLE
Use 400 error for file or upload not found

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -95,7 +95,8 @@ func NewHandler(
 		incRequests(userAgent)
 		file, fileHeader, err := GetFile(r)
 		if err != nil {
-			w.WriteHeader(http.StatusUnsupportedMediaType)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("File or Upload field not found"))
 			logerr("Invalid upload payload", err)
 			return
 		}

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -226,8 +226,8 @@ var _ = Describe("Upload", func() {
 		})
 
 		Context("with an incorrect part name", func() {
-			It("should return HTTP 415", func() {
-				boiler(http.StatusUnsupportedMediaType, &FilePart{
+			It("should return HTTP 400", func() {
+				boiler(http.StatusBadRequest, &FilePart{
 					Name:        "invalid",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test",


### PR DESCRIPTION
We shouldn't send an invalid media type if the type is fine but the
field is missing. Correcting that issue and also writing a message about
what went wrong.

Signed-off-by: Stephen Adams <tsadams@gmail.com>