### PR TITLE
Add service name to payload tracker

### DIFF
--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/redhatinsights/insights-ingress-go/announcers"
@@ -26,7 +27,7 @@ func (p *Pipeline) Tick(ctx context.Context) bool {
 			Account:     ev.Account,
 			RequestID:   ev.RequestID,
 			Status:      "validated",
-			StatusMsg:   "Payload validated by service",
+			StatusMsg:   fmt.Sprintf("Payload validated by service: %s", ev.Service),
 			InventoryID: ev.ID,
 		}
 		l.Log.Info("Validation status received for payload", zap.String("request_id", ev.RequestID))

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -181,7 +181,7 @@ func NewHandler(
 			Account:   vr.Account,
 			RequestID: vr.RequestID,
 			Status:    "processing",
-			StatusMsg: "Sent to validation service",
+			StatusMsg: fmt.Sprintf("Sent to validation service: %s", vr.Service),
 		}
 		l.Log.Info("Payload sent to validation service", logReqID)
 		tracker.Status(ps)


### PR DESCRIPTION
We should write out the service name to payload tracker so we know which
service did the validation

Signed-off-by: Stephen Adams <tsadams@gmail.com>