### PR TITLE
Send batches of logs

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"flag"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -63,7 +64,7 @@ func InitLogger() *logrus.Logger {
 	cfg := aws.NewConfig().WithRegion(region).WithCredentials(cred)
 
 	if key != "" {
-		hook, err := lc.NewHook(group, stream, cfg)
+		hook, err := lc.NewBatchingHook(group, stream, cfg, 30*time.Second)
 		if err != nil {
 			Log.Info(err)
 		} else {

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -77,7 +77,7 @@ func NewHandler(
 	return func(w http.ResponseWriter, r *http.Request) {
 		userAgent := r.Header.Get("User-Agent")
 		reqID := request_id.GetReqID(r.Context())
-		requestLogger := l.Log.WithFields(logrus.Fields{"request_id": reqID, "source_host": cfg.Hostname})
+		requestLogger := l.Log.WithFields(logrus.Fields{"request_id": reqID, "source_host": cfg.Hostname, "name": "ingress"})
 
 		logerr := func(msg string, err error) {
 			requestLogger.WithFields(logrus.Fields{"error": err}).Error(msg)


### PR DESCRIPTION
Send our logs in batches rather than constantly. This could be
contributing to some new errors we're seeing