### PR TITLE
Add service to log message

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -186,7 +186,7 @@ func NewHandler(
 			Status:    "success",
 			StatusMsg: fmt.Sprintf("Sent to validation service: %s", vr.Service),
 		}
-		requestLogger.Info("Payload sent to validation service")
+		requestLogger.WithFields(logrus.Fields{"request_id": reqID, "service": vr.Service}).Info("Payload sent to validation service")
 		tracker.Status(ps)
 
 		validator.Validate(vr)

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -186,7 +186,7 @@ func NewHandler(
 			Status:    "success",
 			StatusMsg: fmt.Sprintf("Sent to validation service: %s", vr.Service),
 		}
-		requestLogger.WithFields(logrus.Fields{"request_id": reqID, "service": vr.Service}).Info("Payload sent to validation service")
+		requestLogger.WithFields(logrus.Fields{"service": vr.Service}).Info("Payload sent to validation service")
 		tracker.Status(ps)
 
 		validator.Validate(vr)


### PR DESCRIPTION
Just adding the service field when we log that something was sent to validation. This is the only way we'll really know where that request_id was headed if something happens and it doesn't make it there.