### PR TITLE
Move the cred and awsconf beneath the key check

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -114,10 +114,9 @@ func InitLogger() *logrus.Logger {
 		ReportCaller: true,
 	}
 
-	cred := credentials.NewStaticCredentials(key, secret, "")
-	awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
-
 	if key != "" {
+		cred := credentials.NewStaticCredentials(key, secret, "")
+		awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
 		hook, err := lc.NewBatchingHook(group, stream, awsconf, 10*time.Second)
 		if err != nil {
 			Log.Info(err)


### PR DESCRIPTION
We dont' need to setup either of these if we don't have a key, so we
might as well move them under this `if`