### PR TITLE
Updated the smoke tests jenkins file

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -2,14 +2,14 @@
  * Requires: https://github.com/RedHatInsights/insights-pipeline-lib
  */
 
-@Library("github.com/RedHatInsights/insights-pipeline-lib") _
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v3") _
 
 
 if (env.CHANGE_ID) {
-    runSmokeTest (
+    execSmokeTest (
         ocDeployerBuilderPath: "platform/ingress",
         ocDeployerComponentPath: "platform/ingress",
-        ocDeployerServiceSets: "advisor,platform,platform-mq",
+        ocDeployerServiceSets: "advisor,ingress,inventory,platform-mq",
         iqePlugins: ["iqe-advisor-plugin", "iqe-upload-plugin", "iqe-host-inventory-plugin"],
         pytestMarker: "smoke",
     )


### PR DESCRIPTION
This change is necessary because the platform set was split into multiple sets:

- ingress -- contains upload service, pup, storage broker, etc.
- inventory -- any app related to inventory (including reaper and host-delete)
- engine -- the shared engine app
- buck-it -- buck-it
- payload-tracker -- payload-tracker front-end/back-end/db