### PR TITLE
Add required fields to HBI POST

### DIFF
--- a/interactions/inventory/inventory.go
+++ b/interactions/inventory/inventory.go
@@ -38,9 +38,7 @@ type HTTP struct {
 func FormatPost(metadata validators.Metadata, account string) ([]byte, error) {
 	metadata.Account = account
 	metadata.Reporter = "ingress"
-	if metadata.StaleTimestamp.IsZero() {
-		metadata.StaleTimestamp = time.Now().AddDate(0, 0, 30)
-	}
+	metadata.StaleTimestamp = time.Now().AddDate(0, 0, 30)
 	return json.Marshal([]validators.Metadata{metadata})
 }
 

--- a/interactions/inventory/inventory.go
+++ b/interactions/inventory/inventory.go
@@ -37,6 +37,7 @@ type HTTP struct {
 // FormatPost returns data in the format that Inventory accepts
 func FormatPost(metadata validators.Metadata, account string) ([]byte, error) {
 	metadata.Account = account
+	metadata.Reporter = "ingress"
 	return json.Marshal([]validators.Metadata{metadata})
 }
 

--- a/interactions/inventory/inventory.go
+++ b/interactions/inventory/inventory.go
@@ -38,6 +38,9 @@ type HTTP struct {
 func FormatPost(metadata validators.Metadata, account string) ([]byte, error) {
 	metadata.Account = account
 	metadata.Reporter = "ingress"
+	if metadata.StaleTimestamp.IsZero() {
+		metadata.StaleTimestamp = time.Now().AddDate(0, 0, 30)
+	}
 	return json.Marshal([]validators.Metadata{metadata})
 }
 

--- a/interactions/inventory/inventory_test.go
+++ b/interactions/inventory/inventory_test.go
@@ -23,7 +23,8 @@ var _ = Describe("Inventory", func() {
 		"subscription_manager_id": "boopboop",
 		"machine_id": "1awekljf234b24bn",
 		"account": "000001",
-		"reporter": "ingress"}`
+		"reporter": "ingress",
+		"stale_timestamp": "2020-02-20T18:33:44.638757+00:00"}`
 
 		invalidJSON string = `{"ip_addresses": ["127.0.0.1"],
 		"fqdn": "localhost.localdomain",
@@ -166,7 +167,7 @@ var _ = Describe("Inventory", func() {
 			Expect(m[0].Account).To(Equal("000001"))
 			Expect(m[0].IPAddresses).To(ContainElement("127.0.0.1"))
 			Expect(m[0].Reporter).To(Equal("ingress"))
-
+			Expect(m[0].StaleTimestamp.IsZero()).To(Equal(false))
 		})
 	})
 })

--- a/interactions/inventory/inventory_test.go
+++ b/interactions/inventory/inventory_test.go
@@ -22,6 +22,15 @@ var _ = Describe("Inventory", func() {
 		"insights_id": "1awekljf234b24bn",
 		"subscription_manager_id": "boopboop",
 		"machine_id": "1awekljf234b24bn",
+		"account": "000001",
+		"reporter": "ingress"}`
+
+		invalidJSON string = `{"ip_addresses": ["127.0.0.1"],
+		"fqdn": "localhost.localdomain",
+		"mac_addresses": ["1234-5678-abcd-efgh"],
+		"insights_id": "1awekljf234b24bn",
+		"subscription_manager_id": "boopboop",
+		"machine_id": "1awekljf234b24bn",
 		"account": "000001"}`
 
 		badJSON string = `notatallajsondoc`
@@ -60,6 +69,19 @@ var _ = Describe("Inventory", func() {
 			id, err := h.GetID(validators.Metadata{}, "", "")
 			Expect(id).To(Equal(""))
 			Expect(err.Error()).To(Equal(invBadResponse + "\n"))
+		})
+
+		It("should fail on missing required fields", func() {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprintln(w, `{"error": "missing required fields: reporter, stale_timestamp"}`)
+			}))
+			defer ts.Close()
+			h := &i.HTTP{Endpoint: ts.URL}
+			id, err := h.GetID(validators.Metadata{}, "", "")
+			Expect(id).To(Equal(""))
+			Expect(err.Error()).To(Equal(`{"error": "missing required fields: reporter, stale_timestamp"}` + "\n"))
 		})
 	})
 
@@ -102,6 +124,25 @@ var _ = Describe("Inventory", func() {
 			Expect(id).To(Equal(""))
 			Expect(err).ToNot(BeNil())
 		})
+
+		It("should fail on missing required fields", func() {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprintln(w, `{"error": "missing required fields: reporter, stale_timestamp"}`)
+			}))
+			defer ts.Close()
+
+			jd := []byte(invalidJSON)
+			res, err := i.Post("12345", jd, ts.URL)
+			Expect(err).To(BeNil())
+			Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(res.Header.Get("Content-Type")).To(Equal("application/json"))
+
+			id, err := i.ParseResponse(res)
+			Expect(id).To(Equal(""))
+			Expect(err).ToNot(BeNil())
+		})
 	})
 
 	Describe("Creating a post", func() {
@@ -124,6 +165,7 @@ var _ = Describe("Inventory", func() {
 			Expect(err).To(BeNil())
 			Expect(m[0].Account).To(Equal("000001"))
 			Expect(m[0].IPAddresses).To(ContainElement("127.0.0.1"))
+			Expect(m[0].Reporter).To(Equal("ingress"))
 
 		})
 	})

--- a/validators/types.go
+++ b/validators/types.go
@@ -29,6 +29,7 @@ type Metadata struct {
 	MacAddresses []string `json:"mac_addresses,omitempty"`
 	FQDN         string   `json:"fqdn,omitempty"`
 	BiosUUID     string   `json:"bios_uuid,omitempty"`
+	Reporter     string   `json:"reporter"`
 }
 
 // ServiceDescriptor is used to select a message topic

--- a/validators/types.go
+++ b/validators/types.go
@@ -21,15 +21,16 @@ type Request struct {
 
 // Metadata is the expected data from a client
 type Metadata struct {
-	IPAddresses  []string `json:"ip_addresses,omitempty"`
-	Account      string   `json:"account,omitempty"`
-	InsightsID   string   `json:"insights_id,omitempty"`
-	MachineID    string   `json:"machine_id,omitempty"`
-	SubManID     string   `json:"subscription_manager_id,omitempty"`
-	MacAddresses []string `json:"mac_addresses,omitempty"`
-	FQDN         string   `json:"fqdn,omitempty"`
-	BiosUUID     string   `json:"bios_uuid,omitempty"`
-	Reporter     string   `json:"reporter"`
+	IPAddresses    []string  `json:"ip_addresses,omitempty"`
+	Account        string    `json:"account,omitempty"`
+	InsightsID     string    `json:"insights_id,omitempty"`
+	MachineID      string    `json:"machine_id,omitempty"`
+	SubManID       string    `json:"subscription_manager_id,omitempty"`
+	MacAddresses   []string  `json:"mac_addresses,omitempty"`
+	FQDN           string    `json:"fqdn,omitempty"`
+	BiosUUID       string    `json:"bios_uuid,omitempty"`
+	Reporter       string    `json:"reporter"`
+	StaleTimestamp time.Time `json:"stale_timestamp"`
 }
 
 // ServiceDescriptor is used to select a message topic


### PR DESCRIPTION
Inventory is requiring the `reporter` and `stale_timestamp` fields be non-null when creating new hosts. Currently, ingress is creating hosts without either of these fields in the metadata. This PR adds both `reporter` and `stale_timestamp` to the metadata when POSTing to inventory.

It sets `reporter` to the static string "ingress". If the metadata coming in from a ingress upload contains a stale_timestamp field, it carries that value along, otherwise it sets the field value to `time.Now().AddDate(0,0,30)` (now plus 30 days).  