### PR TITLE
Fix reporter and timestamp

### DIFF
--- a/interactions/inventory/inventory.go
+++ b/interactions/inventory/inventory.go
@@ -37,8 +37,6 @@ type HTTP struct {
 // FormatPost returns data in the format that Inventory accepts
 func FormatPost(metadata validators.Metadata, account string) ([]byte, error) {
 	metadata.Account = account
-	metadata.Reporter = "ingress"
-	metadata.StaleTimestamp = time.Now().AddDate(0, 0, 30)
 	return json.Marshal([]validators.Metadata{metadata})
 }
 

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -64,6 +64,8 @@ func GetMetadata(r *http.Request) (*validators.Metadata, error) {
 	if err = json.Unmarshal(part, &md); err != nil {
 		return nil, err
 	}
+	md.Reporter = "ingress"
+	md.StaleTimestamp = time.Now().AddDate(0, 0, 30)
 	return &md, nil
 }
 

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Upload", func() {
 				Expect(in).To(Not(BeNil()))
 				vin := validator.In
 				Expect(vin).To(Not(BeNil()))
-				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345"}))
+				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress"}))
 				Expect(vin.ID).To(Equal("1234-abcd-5678-efgh"))
 			})
 		})
@@ -156,7 +156,7 @@ var _ = Describe("Upload", func() {
 				Expect(in).To(Not(BeNil()))
 				vin := validator.In
 				Expect(vin).To(Not(BeNil()))
-				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345"}))
+				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress"}))
 				Expect(vin.ID).To(Equal(""))
 			})
 		})

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/textproto"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -27,6 +28,10 @@ type FilePart struct {
 	Name        string
 	Content     string
 	ContentType string
+}
+
+func setTime() time.Time {
+	return time.Now()
 }
 
 func makeMultipartRequest(uri string, parts ...*FilePart) (*http.Request, error) {
@@ -83,6 +88,7 @@ var _ = Describe("Upload", func() {
 		validator *validators.Fake
 		handler   http.Handler
 		rr        *httptest.ResponseRecorder
+		timeNow   time.Time
 	)
 
 	var boiler = func(code int, parts ...*FilePart) {
@@ -101,6 +107,7 @@ var _ = Describe("Upload", func() {
 
 		rr = httptest.NewRecorder()
 		handler = NewHandler(stager, inventory, validator, tracker, *config.Get())
+		timeNow = setTime()
 	})
 
 	Describe("Posting a file to /upload", func() {
@@ -130,8 +137,9 @@ var _ = Describe("Upload", func() {
 				in := stager.Input
 				Expect(in).To(Not(BeNil()))
 				vin := validator.In
+				vin.Metadata.StaleTimestamp = timeNow
 				Expect(vin).To(Not(BeNil()))
-				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress"}))
+				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress", StaleTimestamp: timeNow}))
 				Expect(vin.ID).To(Equal("1234-abcd-5678-efgh"))
 			})
 		})
@@ -155,8 +163,9 @@ var _ = Describe("Upload", func() {
 				in := stager.Input
 				Expect(in).To(Not(BeNil()))
 				vin := validator.In
+				vin.Metadata.StaleTimestamp = timeNow
 				Expect(vin).To(Not(BeNil()))
-				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress"}))
+				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress", StaleTimestamp: timeNow}))
 				Expect(vin.ID).To(Equal(""))
 			})
 		})


### PR DESCRIPTION
There is a problem where the reporter and stale_timestamps can end up being zero values when sent through to validating services. Moved things around a bit to ensure that they are there.