### PR TITLE
Used multistage build in order to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM golang:1.12
+FROM golang:1.12 as builder
 
 ENV GO111MODULE="on"
 
 WORKDIR /go/src/app
 COPY . .
 
-RUN go get -d ./...
-RUN go install -v ./...
+RUN go get -d ./... && \
+    go install -v ./...
+
+FROM registry.access.redhat.com/ubi8-minimal
+
+COPY --from=builder /go/bin/insights-ingress-go /usr/bin/
+
+USER 1001
 
 CMD ["insights-ingress-go"]


### PR DESCRIPTION
It's not needed to keep golang building infrastructure. We interested only in the resulting binary. Besides resulting image is based on RHEL unlike `golang:1.12`.