### PR TITLE
Handle new content type for advisor

### DIFF
--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -268,6 +268,16 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
+		Context("with new file command legacy type", func() {
+			It("should validate and be processed", func() {
+				boiler(http.StatusAccepted, &FilePart{
+					Name:        "file",
+					Content:     "testing",
+					ContentType: "application/gzip; charset=binary",
+				})
+			})
+		})
+
 		Context("with invalid service name", func() {
 			It("should return 415", func() {
 				boiler(http.StatusUnsupportedMediaType, &FilePart{

--- a/upload/validation.go
+++ b/upload/validation.go
@@ -21,6 +21,11 @@ func getServiceDescriptor(contentType string) (*validators.ServiceDescriptor, er
 			Service:  "advisor",
 			Category: "upload",
 		}, nil
+	case "application/gzip; charset=binary":
+		return &validators.ServiceDescriptor{
+			Service:  "advisor",
+			Category: "upload",
+		}, nil
 	default:
 		m := contentTypePat.FindStringSubmatch(ctype)
 		if m == nil {


### PR DESCRIPTION
In future version of RHEL, a new version of file views the insights
archive with a different file type. This is likely to cause problems
with uploads from those systems.

Fix RHCLOUD-6770

Signed-off-by: Stephen Adams <tsadams@gmail.com>