### PR TITLE
Send legacy response codes when no metadata present

### DIFF
--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -94,6 +94,7 @@ var _ = Describe("Upload", func() {
 		Expect(err).To(BeNil())
 		handler.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(code))
+		Expect(rr.Body).ToNot(BeNil())
 	}
 
 	BeforeEach(func() {
@@ -108,9 +109,9 @@ var _ = Describe("Upload", func() {
 	})
 
 	Describe("Posting a file to /upload", func() {
-		Context("with a valid Content-Type", func() {
-			It("should return HTTP 202", func() {
-				boiler(http.StatusAccepted, &FilePart{
+		Context("with a valid Content-Type and no metadata", func() {
+			It("should return HTTP 201", func() {
+				boiler(http.StatusCreated, &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test"})
@@ -174,8 +175,8 @@ var _ = Describe("Upload", func() {
 		})
 
 		Context("with a valid file part", func() {
-			It("should return a 202", func() {
-				boiler(http.StatusAccepted, &FilePart{
+			It("should return a 201 and no metadata", func() {
+				boiler(http.StatusCreated, &FilePart{
 					Name:        "upload",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test",
@@ -193,9 +194,9 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
-		Context("with a valid Content-Type", func() {
+		Context("with a valid Content-Type and no metadata", func() {
 			It("should invoke the stager", func() {
-				boiler(http.StatusAccepted, &FilePart{
+				boiler(http.StatusCreated, &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test"})
@@ -203,9 +204,9 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
-		Context("with a valid Content-Type", func() {
+		Context("with a valid Content-Type and no metadata", func() {
 			It("should parse to service and category", func() {
-				boiler(http.StatusAccepted, &FilePart{
+				boiler(http.StatusCreated, &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test"})
@@ -218,9 +219,9 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
-		Context("with legacy content type", func() {
+		Context("with legacy content type and no metadata", func() {
 			It("should validate and be processed", func() {
-				boiler(http.StatusAccepted, &FilePart{
+				boiler(http.StatusCreated, &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/x-gzip; charset=binary",
@@ -228,9 +229,9 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
-		Context("with alternate legacy content type", func() {
+		Context("with alternate legacy content type and no metadata", func() {
 			It("should validate and be processed", func() {
-				boiler(http.StatusAccepted, &FilePart{
+				boiler(http.StatusCreated, &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/gzip",
@@ -238,9 +239,9 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
-		Context("with new file command legacy type", func() {
+		Context("with new file command legacy type and no metadata", func() {
 			It("should validate and be processed", func() {
-				boiler(http.StatusAccepted, &FilePart{
+				boiler(http.StatusCreated, &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/gzip; charset=binary",


### PR DESCRIPTION
If the client doesn't send metadata, then this is a legacy upload and
should get a 201 response code with JSON. Since we can't respond with
useful JSON, the body will just be "{}"

Signed-off-by: Stephen Adams <tsadams@gmail.com>