### PR TITLE
Handle the openshift service case

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -204,7 +204,10 @@ func NewHandler(
 		}
 
 		metadata, err := readMetadataPart(r)
-		if metadata != nil {
+		if vr.Service == "openshift" {
+			w.WriteHeader(http.StatusAccepted)
+			w.Write(jsonBody)
+		} else if metadata != nil {
 			w.WriteHeader(http.StatusAccepted)
 			w.Write(jsonBody)
 		} else {

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -118,6 +118,18 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
+		Context("from the openshift operator", func() {
+			It("should return HTTP 202", func() {
+				boiler(http.StatusAccepted,
+					&FilePart{
+						Name:        "file",
+						Content:     "testing",
+						ContentType: "application/vnd.redhat.openshift.test",
+					},
+				)
+			})
+		})
+
 		Context("with a metadata part", func() {
 			It("should return HTTP 202", func() {
 				boiler(http.StatusAccepted,


### PR DESCRIPTION
If openshift operator sends a payload, we need to always respond with a
202 for them. They have a check for that specific return code

Signed-off-by: Stephen Adams <tsadams@gmail.com>