### PR TITLE
Add support for legacy test connection

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -77,7 +77,7 @@ func GetMetadata(r *http.Request) (*validators.Metadata, error) {
 	return &md, nil
 }
 
-func testBody(r *http.Request) bool {
+func isLegacyTestRequest(r *http.Request) bool {
 	r.ParseForm()
 	if r.FormValue("test") == "test" {
 		return true
@@ -114,7 +114,7 @@ func NewHandler(
 			}
 		}
 
-		if testBody(r) {
+		if isLegacyTestRequest(r) {
 			w.WriteHeader(http.StatusOK)
 			return
 		}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -77,6 +77,14 @@ func GetMetadata(r *http.Request) (*validators.Metadata, error) {
 	return &md, nil
 }
 
+func testBody(r *http.Request) bool {
+	r.ParseForm()
+	if r.FormValue("test") == "test" {
+		return true
+	}
+	return false
+}
+
 // NewHandler returns a http handler configured with a Pipeline
 func NewHandler(
 	stager stage.Stager,
@@ -104,6 +112,11 @@ func NewHandler(
 			} else {
 				requestLogger.WithFields(logrus.Fields{"raw_request": dumpBytes}).Info("dumping request")
 			}
+		}
+
+		if testBody(r) {
+			w.WriteHeader(http.StatusOK)
+			return
 		}
 
 		incRequests(userAgent)


### PR DESCRIPTION
The legacy test-connection does a simple post of {"test":"test"} to the
upload endpoint. We need to support this for older clients.

This change just checks for that form data and replies with a 200 status
code.

RHCLOUD-9147

Signed-off-by: Stephen Adams <tsadams@gmail.com>