### PR TITLE
fix: check for minio endpoint to decide stager

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,11 +55,10 @@ func main() {
 	)
 
 	var stager stage.Stager
-	if cfg.UseClowder {
+	if cfg.MinioEndpoint != ""{
 		stager = minio.GetClient(&minio.Stager{
 			Bucket: cfg.StageBucket,
 		})
-
 	} else {
 		stager = &s3.Stager{
 			Bucket: cfg.StageBucket,


### PR DESCRIPTION
We were using the clowder check to decide if minio should be used, but
that was breaking local dev environments that use minio but not clowder.
The check for the minio endpoint should catch both setups while still
allowing old ingress implementations to use s3 (like in v3 smoke tests)

Signed-off-by: Stephen Adams <tsadams@gmail.com>