### PR TITLE
feat: Support legacy test connection

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -1,6 +1,7 @@
 package upload
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,6 +86,20 @@ func isLegacyTestRequest(r *http.Request) bool {
 	return false
 }
 
+func isSatelliteTestRequest(r *http.Request) bool {
+
+	if r.Header.Get("Content-Type") == "application/json" {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		body := buf.String()
+		if body == `{"test": "test"}` {
+			return true
+		}
+	}
+
+	return false
+}
+
 // NewHandler returns a http handler configured with a Pipeline
 func NewHandler(
 	stager stage.Stager,
@@ -115,6 +130,11 @@ func NewHandler(
 		}
 
 		if isLegacyTestRequest(r) {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if isSatelliteTestRequest(r) {
 			w.WriteHeader(http.StatusOK)
 			return
 		}


### PR DESCRIPTION
The old clients send a test payload in the body of the request which we
weren't checking for. This was resulting in 400 error codes particularly
for satellite clients.
This feature support the JSON body implementation of the test connection
feature in the client.

JIRA: https://issues.redhat.com/browse/RHCLOUD-11259

Signed-off-by: Stephen Adams <tsadams@gmail.com>