### PR TITLE
feat: Allow qpc payloads to be larger

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,8 +14,8 @@ import (
 // IngressConfig represents the runtime configuration
 type IngressConfig struct {
 	Hostname             string
-	MaxSize              int64
-	QPCMaxSize			 int64
+	DefaultMaxSize		 int64
+	MaxSizeMap			 map[string]string
 	StageBucket          string
 	Auth                 bool
 	KafkaBrokers         []string
@@ -80,8 +80,8 @@ func Get() *IngressConfig {
 	options.SetDefault("KafkaGroupID", "ingress")
 	options.SetDefault("LogLevel", "INFO")
 	options.SetDefault("Auth", true)
-	options.SetDefault("MaxSize", 100*1024*1024)
-	options.SetDefault("QPCMaxSize", 150*1024*1024)
+	options.SetDefault("DefaultMaxSize", 100*1024*1024)
+	options.SetDefault("MaxSizeMap", `{}`)
 	options.SetDefault("OpenshiftBuildCommit", "notrunninginopenshift")
 	options.SetDefault("ValidTopics", "unit")
 	options.SetDefault("Profile", false)
@@ -96,8 +96,8 @@ func Get() *IngressConfig {
 
 	return &IngressConfig{
 		Hostname:             kubenv.GetString("Hostname"),
-		MaxSize:              options.GetInt64("MaxSize"),
-		QPCMaxSize:			  options.GetInt64("QPCMaxSize"),
+		DefaultMaxSize:       options.GetInt64("DefaultMaxSize"),
+		MaxSizeMap:			  options.GetStringMapString("MaxSizeMap"),
 		StageBucket:          options.GetString("StageBucket"),
 		Auth:                 options.GetBool("Auth"),
 		KafkaBrokers:         options.GetStringSlice("KafkaBrokers"),

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 type IngressConfig struct {
 	Hostname             string
 	MaxSize              int64
+	QPCMaxSize			 int64
 	StageBucket          string
 	Auth                 bool
 	KafkaBrokers         []string
@@ -80,6 +81,7 @@ func Get() *IngressConfig {
 	options.SetDefault("LogLevel", "INFO")
 	options.SetDefault("Auth", true)
 	options.SetDefault("MaxSize", 100*1024*1024)
+	options.SetDefault("QPCMaxSize", 150*1024*1024)
 	options.SetDefault("OpenshiftBuildCommit", "notrunninginopenshift")
 	options.SetDefault("ValidTopics", "unit")
 	options.SetDefault("Profile", false)
@@ -95,6 +97,7 @@ func Get() *IngressConfig {
 	return &IngressConfig{
 		Hostname:             kubenv.GetString("Hostname"),
 		MaxSize:              options.GetInt64("MaxSize"),
+		QPCMaxSize:			  options.GetInt64("QPCMaxSize"),
 		StageBucket:          options.GetString("StageBucket"),
 		Auth:                 options.GetBool("Auth"),
 		KafkaBrokers:         options.GetStringSlice("KafkaBrokers"),

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -115,8 +115,10 @@ parameters:
   value: advisor,compliance,hccm,qpc,rhv,tower,leapp-reporting,topological-inventory,buckit,xavier,mkt,catalog,playbook,resource-optimization
 - name: INGRESS_INVENTORYURL
   value: http://insights-inventory:8080/api/inventory/v1/hosts
-- name: INGRESS_MAXSIZE
+- name: INGRESS_DEFAULTMAXSIZE
   value: '104857600'
+- name: INGRESS_MAXSIZEMAP
+  value: '{"qpc": "157286400"}'
 - name: LOG_LEVEL
   value: INFO
 - description: Cpu limit of service

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/redhatinsights/insights-ingress-go/announcers"
@@ -29,13 +30,6 @@ type responseBody struct {
 
 type uploadData struct {
 	Account string `json:"account_number,omitempty"`
-}
-
-var contentSizeMap map[string]int64
-
-func init() {
-	contentSizeMap = make(map[string]int64)
-	contentSizeMap["qpc"] = config.Get().QPCMaxSize
 }
 
 // GetFile verifies that the proper upload field is in place and returns the file
@@ -196,11 +190,12 @@ func NewHandler(
 
 		var exceedsSizeLimit bool
 
-		if val, ok := contentSizeMap[vr.Service]; ok {
-			if fileHeader.Size > val {
+		if val, ok := cfg.MaxSizeMap[vr.Service]; ok {
+			fileSize, _ := strconv.ParseInt(val, 10, 64)
+			if fileHeader.Size > fileSize {
 				exceedsSizeLimit = true
 			}
-		} else if fileHeader.Size > cfg.MaxSize {
+		} else if fileHeader.Size > cfg.DefaultMaxSize {
 			exceedsSizeLimit = true
 		} else {
 			exceedsSizeLimit = false

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -347,7 +347,7 @@ var _ = Describe("Upload", func() {
 		Context("with content that is larger than the max allowed size", func() {
 			It("should return 413", func() {
 				cfg := config.Get()
-				cfg.MaxSize = 1
+				cfg.DefaultMaxSize = 1
 				handler = NewHandler(stager, validator, tracker, *cfg)
 				boiler(http.StatusRequestEntityTooLarge, &FilePart{
 					Name:        "file",
@@ -359,8 +359,11 @@ var _ = Describe("Upload", func() {
 
 		Context("with content type of qpc that is larger than global allowed size", func() {
 			It("should return a 202", func() {
+				TypeMap := make(map[string]string)
+				TypeMap["qpc"] = "157286400"
 				cfg := config.Get()
-				cfg.MaxSize = 1
+				cfg.DefaultMaxSize = 1
+				cfg.MaxSizeMap = TypeMap
 				handler = NewHandler(stager, validator, tracker, *cfg)
 				boiler(http.StatusAccepted, &FilePart{
 					Name: "file",

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -357,6 +357,19 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
+		Context("with content type of qpc that is larger than global allowed size", func() {
+			It("should return a 202", func() {
+				cfg := config.Get()
+				cfg.MaxSize = 1
+				handler = NewHandler(stager, validator, tracker, *cfg)
+				boiler(http.StatusAccepted, &FilePart{
+					Name: "file",
+					Content: "testing",
+					ContentType: "application/vnd.redhat.qpc.test",
+				})
+			})
+		})
+
 		Context("when the payload fails to stage", func() {
 			It("should return 413", func() {
 				stager = &stage.Fake{ShouldError: true}


### PR DESCRIPTION
Increasing the accepted size of qpc uploads to 150MB. This service sends
up multiple systems in a single archive and the archive can easily
exceed our current max size limit

Signed-off-by: Stephen Adams <tsadams@gmail.com>