### PR TITLE
Use the config object that is injected into the upload handler instead of getting a new instance of the config object

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -117,7 +117,7 @@ func NewHandler(
 			requestLogger.WithFields(logrus.Fields{"error": err}).Error(msg)
 		}
 
-		if config.Get().Auth == true {
+		if cfg.Auth == true {
 			id = identity.Get(r.Context())
 		}
 
@@ -207,7 +207,7 @@ func NewHandler(
 			return
 		}
 
-		if config.Get().Auth == true {
+		if cfg.Auth == true {
 			vr.Account = id.Identity.AccountNumber
 			vr.Principal = id.Identity.Internal.OrgID
 			requestLogger = requestLogger.WithFields(logrus.Fields{"account": vr.Account, "orgid": vr.Principal})


### PR DESCRIPTION
The config object is getting injected into the upload handler object.  However, in a couple of places, the code is getting a new instance of the config object.  This likely only makes a difference in your test code as the test code is making changes to the injected config object just before running the test.