### PR TITLE
fix: remove binutils from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN go get -d ./... && \
 RUN cp /opt/app-root/src/go/bin/insights-ingress-go /usr/bin/ && \
     cp /go/src/app/openapi.json /var/tmp/
 
-RUN yum remove -y kernel-headers npm nodejs nodejs-full-i18n && yum update -y && yum clean all
+RUN REMOVE_PKGS="kernel-headers npm nodejs nodejs-full-i18n binutils" && \
+    yum remove -y $REMOVE_PKGS && \
+    yum clean all
 
 USER 1001
 CMD ["insights-ingress-go"]


### PR DESCRIPTION
We don't use binutils, so we're removing it from our image.
This will help with our vulnerabilities in the future.

Signed-off-by: Stephen Adams <tsadams@gmail.com>