### PR TITLE
fix: Change the defaults for the minio directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 insights-ingress-go
 .idea
 coverage.txt
+.scannerwork

--- a/development/local-dev-start.yml
+++ b/development/local-dev-start.yml
@@ -27,8 +27,8 @@ services:
       # These vars are defined in .env
       # These are configurable
       # Ensure the directories exist prior to running this file
-      - minio_conf:/root/.minio:Z
-      - minio_data:/data:Z
+      - minio_conf:$MINIO_CONFIG_DIR
+      - minio_data:$MINIO_DATA_DIR
     ports:
       - 9000:9000
     environment:

--- a/development/minio-conf/.gitignore
+++ b/development/minio-conf/.gitignore
@@ -1,0 +1,7 @@
+# This file is a placeholder in order to add these default
+# directories to the repo
+
+# Ignore everything in this direcotry
+*
+# Ignore the gitignore file
+!.gitignore

--- a/development/minio-data/.gitignore
+++ b/development/minio-data/.gitignore
@@ -1,0 +1,7 @@
+# This file is a placeholder in order to add these default
+# directories to the repo
+
+# Ignore everything in this direcotry
+*
+# Ignore the gitignore file
+!.gitignore


### PR DESCRIPTION
In the podman-compose we had these hard coded, but we should pull the
ones that are in the `.env` file

Signed-off-by: Stephen Adams <tsadams@gmail.com>