### PR TITLE
[task] Update our dockerfile to use a minimal image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/go-toolset
+FROM registry.redhat.io/ubi8/go-toolset as builder
 
 WORKDIR /go/src/app
 COPY . .
@@ -11,9 +11,13 @@ RUN go get -d ./... && \
 RUN cp /opt/app-root/src/go/bin/insights-ingress-go /usr/bin/ && \
     cp /go/src/app/openapi.json /var/tmp/
 
-RUN REMOVE_PKGS="kernel-headers npm nodejs nodejs-full-i18n binutils" && \
-    yum remove -y $REMOVE_PKGS && \
-    yum clean all
+FROM registry.redhat.io/ubi8/ubi-minimal
+
+WORKDIR /
+
+COPY --from=builder /opt/app-root/src/go/bin/insights-ingress-go ./insights-ingress-go
+COPY --from=builder /go/src/app/openapi.json /var/tmp
 
 USER 1001
-CMD ["insights-ingress-go"]
+
+CMD ["/insights-ingress-go"]


### PR DESCRIPTION
We only need go dev tools during build. Using this new dockerfile will
allow us to ditch the heavy builder image and use a minimal image to
actually run the executable.

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
