### PR TITLE
[fix] add new line to log messages

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -70,6 +70,9 @@ func (f *CustomCloudwatch) Format(entry *logrus.Entry) ([]byte, error) {
 		return nil, err
 	}
 
+	// Add newline to make stdout readable
+	j = append(j, 0x0a)
+
 	b.Write(j)
 
 	return b.Bytes(), nil


### PR DESCRIPTION
stdout is impossible to read without appending a new line to log
messages

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
