### PR TITLE
[feat] Add payload tracking endpoin

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type IngressConfig struct {
 	Profile              bool
 	OpenshiftBuildCommit string
 	Version              string
+	PayloadTrackerURL  string
 	MinioEndpoint        string
 	MinioAccessKey       string
 	MinioSecretKey       string
@@ -79,6 +80,7 @@ func Get() *IngressConfig {
 	options.SetDefault("KafkaTrackerTopic", "platform.payload-status")
 	options.SetDefault("KafkaGroupID", "ingress")
 	options.SetDefault("LogLevel", "INFO")
+	options.SetDefault("PayloadTrackerURL", "http://payload-tracker/v1/payloads/")
 	options.SetDefault("Auth", true)
 	options.SetDefault("DefaultMaxSize", 100*1024*1024)
 	options.SetDefault("MaxSizeMap", `{}`)
@@ -106,6 +108,7 @@ func Get() *IngressConfig {
 		ValidTopics:          strings.Split(options.GetString("ValidTopics"), ","),
 		WebPort:              options.GetInt("WebPort"),
 		MetricsPort:          options.GetInt("MetricsPort"),
+		PayloadTrackerURL:   options.GetString("PayloadTrackerURL"),
 		Profile:              options.GetBool("Profile"),
 		Debug:                options.GetBool("Debug"),
 		DebugUserAgent:       regexp.MustCompile(options.GetString("DebugUserAgent")),

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bshuster-repo/logrus-logstash-hook v0.4.1
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/jarcoal/httpmock v1.0.8
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kdar/gtest v0.0.0-20171003232747-b20da4453579
 	github.com/kdar/logrus-cloudwatchlogs v0.0.0-20190402042352-9a67b2f09ba3

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jarcoal/httpmock v1.0.8 h1:8kI16SoO6LQKgPE7PvQuV+YuD/inwHd7fOOe2zMbo4k=
+github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/track/track.go
+++ b/track/track.go
@@ -1,0 +1,65 @@
+package track
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/redhatinsights/insights-ingress-go/config"
+	l "github.com/redhatinsights/insights-ingress-go/logger"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+
+	"github.com/sirupsen/logrus"
+)
+
+// NewHandlers returns an http handler for tracking
+func NewHandler(
+	cfg config.IngressConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var id identity.XRHID
+		reqID := chi.URLParam(r, "requestID")
+		requestLogger := l.Log.WithFields(logrus.Fields{"source_host": cfg.Hostname, "name": "ingress"})
+
+		logerr := func(msg string, err error) {
+			requestLogger.WithFields(logrus.Fields{"error": err}).Error(msg)
+		}
+
+		if cfg.Auth == true {
+			id = identity.Get(r.Context())
+		}
+
+		response, err := http.Get(cfg.PayloadTrackerURL + reqID)
+		if err != nil {
+			logerr("Failed to get payload status", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		body, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			logerr("Unable to read response body", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var pt TrackerResponse
+		if err = json.Unmarshal(body, &pt); err != nil {
+			logerr("Failed to unmarshal tracker json", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if len(pt.Data) == 0 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		if pt.Data[0].Account != id.Identity.AccountNumber {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+
+	}
+}

--- a/track/track_suite_test.go
+++ b/track/track_suite_test.go
@@ -1,0 +1,15 @@
+package track_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	l "github.com/redhatinsights/insights-ingress-go/logger"
+)
+
+func TestTrack(t *testing.T) {
+	RegisterFailHandler(Fail)
+	l.InitLogger()
+	RunSpecs(t, "Track Suite")
+}

--- a/track/track_test.go
+++ b/track/track_test.go
@@ -1,0 +1,95 @@
+package track_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-chi/chi"
+	"github.com/jarcoal/httpmock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/insights-ingress-go/config"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+
+	. "github.com/redhatinsights/insights-ingress-go/track"
+)
+
+func makeTestRequest(uri string, request_id string, account string) (*http.Request, error) {
+
+	var req *http.Request
+	var err error
+
+	req, err = http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("request-id", request_id)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
+		Identity: identity.Identity{
+			AccountNumber: account,
+			Internal: identity.Internal{
+				OrgID: "12345",
+			},
+		},
+	})
+
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	return req, nil
+
+}
+
+var _ = Describe("Track", func() {
+	var (
+		handler http.Handler
+		rr *httptest.ResponseRecorder
+		goodJsonBody = `{"data":[{"id":7738149,"status_msg":"Received message","date":"2021-06-11 20:12:39.219543+00:00","created_at":"2021-06-11 20:12:39.303714+00:00","request_id":"747c1300667b441e8e8f448337588ec0","account":"6089719","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","system_id":"b1596dc8-fb46-4e16-8790-d11ea7dfa16a","service":"puptoo","status":"received"},{"id":7738150,"status_msg":"Message sent to inventory","date":"2021-06-11 20:12:40.212302+00:00","created_at":"2021-06-11 20:12:40.269223+00:00","request_id":"747c1300667b441e8e8f448337588ec0","account":"6089719","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","system_id":"b1596dc8-fb46-4e16-8790-d11ea7dfa16a","service":"puptoo","status":"success"},{"id":7738152,"status_msg":"message received","date":"2021-06-11 20:12:40.228334+00:00","created_at":"2021-06-11 20:12:40.375706+00:00","request_id":"747c1300667b441e8e8f448337588ec0","account":"6089719","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","system_id":"b1596dc8-fb46-4e16-8790-d11ea7dfa16a","service":"inventory-mq-service","status":"received"}],"duration":{"hsp-archiver:undefined":"0:00:00.067749","storage-broker:undefined":"0:00:00","puptoo:undefined":"0:00:00.992759","inventory-mq-service:undefined":"0:00:00.102472","vulnerability-rules:undefined":"0:00:01.155458","insights-engine:undefined":"0:00:01.691324","vulnerability-vmaas:undefined":"0:00:02.812779","insights-advisor-service:insights-client":"0:00:00.066972","total_time_in_services":"0:00:06.889513","total_time":"0:00:04.038974"}}`
+		badJsonID = `{"data": [], "duration": {}}`
+	)
+
+	BeforeEach(func() {
+
+		rr = httptest.NewRecorder()
+		handler = NewHandler(*config.Get())
+		httpmock.Activate()
+	})
+
+	Describe("Get request id", func() {
+		Context("with a valid request-id", func() {
+			It("should return HTTP 200", func() {
+				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089719")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(200))
+				Expect(rr.Body).ToNot(BeNil())
+				Expect(rr.Body.String()).To(Equal(goodJsonBody))
+			})
+		})
+
+		Context("with an invalid request-id", func () {
+			It("should return HTTP 404", func () {
+				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, badJsonID))
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089719")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(404))
+			})
+		})
+
+		Context("with an incorrect account", func() {
+			It("should return an HTTP 403", func () {
+				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(403))
+			})
+		})
+	})
+})

--- a/track/types.go
+++ b/track/types.go
@@ -1,0 +1,17 @@
+package track
+
+type TrackerResponse struct {
+	Data []Status `json:"data"`
+	Duration interface{} `json:"duration"`
+}
+
+type Status struct {
+	StatusMsg string `json:"status_msg,omitempty"`
+	Date string `json:"date,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	RequestID string `json:"request_id,omitempty"`
+	Account string `json:"account,omitempty"`
+	InventoryID string `json:"inventory_id,omitempty"`
+	Service string `json:"service,omitempty"`
+	Status string `json:"status,omitempty"`
+}


### PR DESCRIPTION
This allows users to hit a /track endpoint on ingress to check where
their payload is in the process of beign ingested into the platform.
Currently it will just return the JSON provided by payload tracker
directly. It will be up to the end user or potentially the client to
pick out the needed data.

This is a first pass, so there's plenty of room for improvement as we
move forward.

RHCLOUD-14381

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
