### PR TITLE
Configurable kafka in non-clowderized environment

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,19 +14,19 @@ import (
 // IngressConfig represents the runtime configuration
 type IngressConfig struct {
 	Hostname             string
-	DefaultMaxSize		 int64
-	MaxSizeMap			 map[string]string
-	MaxUploadMem		 int64
+	DefaultMaxSize       int64
+	MaxSizeMap           map[string]string
+	MaxUploadMem         int64
 	StageBucket          string
 	Auth                 bool
 	KafkaBrokers         []string
 	KafkaGroupID         string
 	KafkaTrackerTopic    string
-	KafkaCA				 string
-	KafkaUsername		 string
-	KafkaPassword		 string
-	KafkaDeliveryReports	   	 bool
-	SASLMechanism		 string
+	KafkaCA              string
+	KafkaUsername        string
+	KafkaPassword        string
+	KafkaDeliveryReports bool
+	SASLMechanism        string
 	Protocol             string
 	ValidTopics          []string
 	WebPort              int
@@ -34,7 +34,7 @@ type IngressConfig struct {
 	Profile              bool
 	OpenshiftBuildCommit string
 	Version              string
-	PayloadTrackerURL  string
+	PayloadTrackerURL    string
 	MinioEndpoint        string
 	MinioAccessKey       string
 	MinioSecretKey       string
@@ -76,7 +76,11 @@ func Get() *IngressConfig {
 	} else {
 		options.SetDefault("WebPort", 3000)
 		options.SetDefault("MetricsPort", 8080)
-		options.SetDefault("KafkaBrokers", []string{"kafka:29092"})
+		defaultBrokers := os.Getenv("INGRESS_KAFKA_BROKERS")
+		if len(defaultBrokers) == 0 {
+			defaultBrokers = "kafka:29092"
+		}
+		options.SetDefault("KafkaBrokers", []string{defaultBrokers})
 		options.SetDefault("StageBucket", "available")
 		options.SetDefault("LogGroup", "platform-dev")
 		options.SetDefault("AwsRegion", "us-east-1")
@@ -110,7 +114,7 @@ func Get() *IngressConfig {
 	ingressCfg := &IngressConfig{
 		Hostname:             kubenv.GetString("Hostname"),
 		DefaultMaxSize:       options.GetInt64("DefaultMaxSize"),
-		MaxSizeMap:			  options.GetStringMapString("MaxSizeMap"),
+		MaxSizeMap:           options.GetStringMapString("MaxSizeMap"),
 		MaxUploadMem:         options.GetInt64("MaxUploadMem"),
 		StageBucket:          options.GetString("StageBucket"),
 		Auth:                 options.GetBool("Auth"),
@@ -121,7 +125,7 @@ func Get() *IngressConfig {
 		ValidTopics:          strings.Split(options.GetString("ValidTopics"), ","),
 		WebPort:              options.GetInt("WebPort"),
 		MetricsPort:          options.GetInt("MetricsPort"),
-		PayloadTrackerURL:   options.GetString("PayloadTrackerURL"),
+		PayloadTrackerURL:    options.GetString("PayloadTrackerURL"),
 		Profile:              options.GetBool("Profile"),
 		Debug:                options.GetBool("Debug"),
 		DebugUserAgent:       regexp.MustCompile(options.GetString("DebugUserAgent")),
@@ -138,7 +142,7 @@ func Get() *IngressConfig {
 		UseSSL:               options.GetBool("UseSSL"),
 		UseClowder:           os.Getenv("CLOWDER_ENABLED") == "true",
 	}
-	
+
 	if os.Getenv("CLOWDER_ENABLED") == "true" {
 		cfg := clowder.LoadedConfig
 		broker := cfg.Kafka.Brokers[0]

--- a/development/README.md
+++ b/development/README.md
@@ -35,7 +35,7 @@ In the root of the insights-ingress-go repo, execute the following commands:
 There should now be an executable in the directory. You need to supply some env vars for the application to work
 properly. Here is an example:
 
-    $> INGRESS_STAGEBUCKET=insights-upload-perma INGRESS_VALIDTOPICS=advisor OPENSHIFT_BUILD_COMMIT=somestring INGRESS_MINIODEV=true INGRESS_MINIOACCESSKEY=$MINIO_ACCESS_KEY INGRESS_MINIOSECRETKEY=$MINIO_SECRET_KEY INGRESS_MINIOENDPOINT=localhost:9000 ./insights-ingress-go
+    $> INGRESS_STAGEBUCKET=insights-upload-perma INGRESS_VALIDTOPICS=advisor OPENSHIFT_BUILD_COMMIT=somestring INGRESS_MINIODEV=true INGRESS_MINIOACCESSKEY=$MINIO_ACCESS_KEY INGRESS_MINIOSECRETKEY=$MINIO_SECRET_KEY INGRESS_KAFKA_BROKERS=localhost:9092 INGRESS_MINIOENDPOINT=localhost:9000 ./insights-ingress-go
 
 ## Running from Podman
 


### PR DESCRIPTION
Kafka brokers were hardcoded to `kafka:29092` in case of local(no-clowder) settings. It's not compatible i.e. with automation-analytics. 
Adding INGRESS_KAFKA_BROKERS environment variable.

The rest is automatic spaces reformating by VSCode