### PR TITLE
[fix] add delivery report false

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ type IngressConfig struct {
 	KafkaCA				 string
 	KafkaUsername		 string
 	KafkaPassword		 string
-	DeliveryReports	   	 bool
+	KafkaDeliveryReports	   	 bool
 	SASLMechanism		 string
 	Protocol             string
 	ValidTopics          []string
@@ -87,7 +87,7 @@ func Get() *IngressConfig {
 
 	options.SetDefault("KafkaTrackerTopic", "platform.payload-status")
 	options.SetDefault("KafkaGroupID", "ingress")
-	options.SetDefault("DeliveryReports", false)
+	options.SetDefault("KafkaDeliveryReports", false)
 	options.SetDefault("LogLevel", "INFO")
 	options.SetDefault("PayloadTrackerURL", "http://payload-tracker/v1/payloads/")
 	options.SetDefault("Auth", true)
@@ -114,7 +114,7 @@ func Get() *IngressConfig {
 		KafkaBrokers:         options.GetStringSlice("KafkaBrokers"),
 		KafkaGroupID:         options.GetString("KafkaGroupID"),
 		KafkaTrackerTopic:    options.GetString("KafkaTrackerTopic"),
-		DeliveryReports:       options.GetBool("DeliveryReports"),
+		KafkaDeliveryReports:       options.GetBool("KafkaDeliveryReports"),
 		ValidTopics:          strings.Split(options.GetString("ValidTopics"), ","),
 		WebPort:              options.GetInt("WebPort"),
 		MetricsPort:          options.GetInt("MetricsPort"),

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type IngressConfig struct {
 	KafkaCA				 string
 	KafkaUsername		 string
 	KafkaPassword		 string
+	DeliveryReports	   	 bool
 	SASLMechanism		 string
 	Protocol             string
 	ValidTopics          []string
@@ -86,6 +87,7 @@ func Get() *IngressConfig {
 
 	options.SetDefault("KafkaTrackerTopic", "platform.payload-status")
 	options.SetDefault("KafkaGroupID", "ingress")
+	options.SetDefault("DeliveryReports", false)
 	options.SetDefault("LogLevel", "INFO")
 	options.SetDefault("PayloadTrackerURL", "http://payload-tracker/v1/payloads/")
 	options.SetDefault("Auth", true)
@@ -112,6 +114,7 @@ func Get() *IngressConfig {
 		KafkaBrokers:         options.GetStringSlice("KafkaBrokers"),
 		KafkaGroupID:         options.GetString("KafkaGroupID"),
 		KafkaTrackerTopic:    options.GetString("KafkaTrackerTopic"),
+		DeliveryReports:       options.GetBool("DeliveryReports"),
 		ValidTopics:          strings.Split(options.GetString("ValidTopics"), ","),
 		WebPort:              options.GetInt("WebPort"),
 		MetricsPort:          options.GetInt("MetricsPort"),

--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ func main() {
 		Brokers: cfg.KafkaBrokers,
 		Topic: cfg.KafkaTrackerTopic,
 		Async: true,
+		DeliveryReports: cfg.DeliveryReports,
 	}
 
 	if cfg.KafkaCA != "" {

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 		Brokers: cfg.KafkaBrokers,
 		Topic: cfg.KafkaTrackerTopic,
 		Async: true,
-		DeliveryReports: cfg.DeliveryReports,
+		KafkaDeliveryReports: cfg.KafkaDeliveryReports,
 	}
 
 	if cfg.KafkaCA != "" {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -45,11 +45,12 @@ func Producer(in chan []byte, config *ProducerConfig) {
 			"ssl.ca.location": config.CA,
 			"sasl.username": config.Username,
 			"sasl.password": config.Password,
-			"go.delivery.reports": false,
+			"go.delivery.reports": config.DeliveryReports,
 		}
 	} else {
 		configMap = kafka.ConfigMap{
 			"bootstrap.servers": config.Brokers[0],
+			"go.delivery.reports": config.DeliveryReports,
 		}
 	}
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -45,12 +45,12 @@ func Producer(in chan []byte, config *ProducerConfig) {
 			"ssl.ca.location": config.CA,
 			"sasl.username": config.Username,
 			"sasl.password": config.Password,
-			"go.delivery.reports": config.DeliveryReports,
+			"go.delivery.reports": config.KafkaDeliveryReports,
 		}
 	} else {
 		configMap = kafka.ConfigMap{
 			"bootstrap.servers": config.Brokers[0],
-			"go.delivery.reports": config.DeliveryReports,
+			"go.delivery.reports": config.KafkaDeliveryReports,
 		}
 	}
 

--- a/queue/types.go
+++ b/queue/types.go
@@ -10,4 +10,5 @@ type ProducerConfig struct {
 	CA        string
 	Protocol  string
 	SASLMechanism string
+	DeliveryReports bool
 }

--- a/queue/types.go
+++ b/queue/types.go
@@ -10,5 +10,5 @@ type ProducerConfig struct {
 	CA        string
 	Protocol  string
 	SASLMechanism string
-	DeliveryReports bool
+	KafkaDeliveryReports bool
 }


### PR DESCRIPTION
Need to make sure delivery reports are false for both SSL and non-SSL
kafka connections. Also made it configurable with a `false` default
value

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
