### PR TITLE
[task] rewrite the failure logic

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -63,6 +63,9 @@ func Producer(in chan []byte, config *ProducerConfig) {
 
 	defer p.Close()
 
+	// Read the Events() channel for this producer, if an Error exists in the TopicPartition, then put the
+	// message back in the queue to be reprocessed. This is to keep messages from getting lost in the event
+	// of a brief kafka outage.
 	go func() {
 		for e := range p.Events() {
 			switch ev := e.(type) {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -69,7 +69,10 @@ func Producer(in chan []byte, config *ProducerConfig) {
 			case *kafka.Message:	
 				if ev.TopicPartition.Error != nil {
 					l.Log.WithFields(logrus.Fields{"error": ev.TopicPartition.Error}).Error("Error publishing to kafka")
+					in <- ev.Value
+					publishFailures.With(prom.Labels{"topic": config.Topic}).Inc()
 				} else {
+					messagesPublished.With(prom.Labels{"topic": config.Topic}).Inc()
 					l.Log.Info("Message published to kafka")
 				}
 			}
@@ -81,7 +84,7 @@ func Producer(in chan []byte, config *ProducerConfig) {
 			producerCount.Inc()
 			defer producerCount.Dec()
 			start := time.Now()
-			err := p.Produce(&kafka.Message{
+			p.Produce(&kafka.Message{
 				TopicPartition: kafka.TopicPartition{
 					Topic:     &config.Topic,
 					Partition: kafka.PartitionAny,
@@ -89,15 +92,6 @@ func Producer(in chan []byte, config *ProducerConfig) {
 				Value: v,
 			}, nil)
 			messagePublishElapsed.With(prom.Labels{"topic": config.Topic}).Observe(time.Since(start).Seconds())
-
-			if err != nil {
-				l.Log.WithFields(logrus.Fields{"error": err}).Error("error while writing, putting message back into channel")
-				in <- v
-				publishFailures.With(prom.Labels{"topic": config.Topic}).Inc()
-				return
-			} else {
-				messagesPublished.With(prom.Labels{"topic": config.Topic}).Inc()
-			}
 		}(v)
 	}
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -39,17 +39,17 @@ func Producer(in chan []byte, config *ProducerConfig) {
 
 	if config.SASLMechanism != "" {
 		configMap = kafka.ConfigMap{
-			"bootstrap.servers": config.Brokers[0],
-			"security.protocol": config.Protocol,
-			"sasl.mechanism": config.SASLMechanism,
-			"ssl.ca.location": config.CA,
-			"sasl.username": config.Username,
-			"sasl.password": config.Password,
+			"bootstrap.servers":   config.Brokers[0],
+			"security.protocol":   config.Protocol,
+			"sasl.mechanism":      config.SASLMechanism,
+			"ssl.ca.location":     config.CA,
+			"sasl.username":       config.Username,
+			"sasl.password":       config.Password,
 			"go.delivery.reports": config.KafkaDeliveryReports,
 		}
 	} else {
 		configMap = kafka.ConfigMap{
-			"bootstrap.servers": config.Brokers[0],
+			"bootstrap.servers":   config.Brokers[0],
 			"go.delivery.reports": config.KafkaDeliveryReports,
 		}
 	}
@@ -66,7 +66,7 @@ func Producer(in chan []byte, config *ProducerConfig) {
 	go func() {
 		for e := range p.Events() {
 			switch ev := e.(type) {
-			case *kafka.Message:	
+			case *kafka.Message:
 				if ev.TopicPartition.Error != nil {
 					l.Log.WithFields(logrus.Fields{"error": ev.TopicPartition.Error}).Error("Error publishing to kafka")
 					in <- ev.Value


### PR DESCRIPTION
Instead of handling everything related to failures in our own function.
We should use the delivery reports to determine a failure and then put
it back in our channel if it fails.

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
