### PR TITLE
[feat] Create single topic for new uploads

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -115,6 +115,9 @@ objects:
     - replicas: 3
       partitions: 3
       topicName: platform.upload.resource-optimization
+    - replicas: 3
+      partitions: 64
+      topicName: platform.upload.announce
 
 parameters:
 - name: INGRESS_STAGEBUCKET

--- a/internal/announcers/kafka.go
+++ b/internal/announcers/kafka.go
@@ -57,7 +57,8 @@ func (k *Kafka) Status(vs *Status) {
 	}()
 	message := validators.ValidationMessage{
 		Headers: map[string]string{
-			"service": vs.Service,
+			"Key": "service",
+			"Value": vs.Service,
 		},
 		Message: data,
 	}

--- a/internal/announcers/kafka.go
+++ b/internal/announcers/kafka.go
@@ -57,8 +57,7 @@ func (k *Kafka) Status(vs *Status) {
 	}()
 	message := validators.ValidationMessage{
 		Headers: map[string]string{
-			"Key": "service",
-			"Value": vs.Service,
+			"service": vs.Service,
 		},
 		Message: data,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type IngressConfig struct {
 	KafkaUsername        string
 	KafkaPassword        string
 	KafkaDeliveryReports bool
+	AnnounceTopic		 string
 	SASLMechanism        string
 	Protocol             string
 	ValidTopics          []string
@@ -94,13 +95,14 @@ func Get() *IngressConfig {
 	options.SetDefault("KafkaTrackerTopic", "platform.payload-status")
 	options.SetDefault("KafkaGroupID", "ingress")
 	options.SetDefault("KafkaDeliveryReports", true)
+	options.SetDefault("AnnounceTopic", "platform.upload.announce")
 	options.SetDefault("LogLevel", "INFO")
 	options.SetDefault("PayloadTrackerURL", "http://payload-tracker/v1/payloads/")
 	options.SetDefault("Auth", true)
 	options.SetDefault("DefaultMaxSize", 100*1024*1024)
 	options.SetDefault("MaxSizeMap", `{}`)
 	options.SetDefault("OpenshiftBuildCommit", "notrunninginopenshift")
-	options.SetDefault("ValidTopics", "unit")
+	options.SetDefault("ValidTopics", "unit,announce")
 	options.SetDefault("Profile", false)
 	options.SetDefault("Debug", false)
 	options.SetDefault("DebugUserAgent", `unspecified`)
@@ -122,6 +124,7 @@ func Get() *IngressConfig {
 		KafkaGroupID:         options.GetString("KafkaGroupID"),
 		KafkaTrackerTopic:    options.GetString("KafkaTrackerTopic"),
 		KafkaDeliveryReports: options.GetBool("KafkaDeliveryReports"),
+		AnnounceTopic: 	      options.GetString("AnnounceTopic"),
 		ValidTopics:          strings.Split(options.GetString("ValidTopics"), ","),
 		WebPort:              options.GetInt("WebPort"),
 		MetricsPort:          options.GetInt("MetricsPort"),

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,10 +1,10 @@
 package queue
 
 import (
-	"encoding/json"
 	"time"
 
 	l "github.com/redhatinsights/insights-ingress-go/internal/logger"
+	val "github.com/redhatinsights/insights-ingress-go/internal/validators"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 
@@ -44,14 +44,10 @@ type ProducerConfig struct {
 	KafkaDeliveryReports bool
 }
 
-type ServiceDef struct {
-	Service string `json:"service,omitempty"`
-}
-
 // Producer consumes in and produces to the topic in config
 // Each message is sent to the writer via a goroutine so that the internal batch
 // buffer has an opportunity to fill.
-func Producer(in chan []byte, config *ProducerConfig) {
+func Producer(in chan val.Transport, config *ProducerConfig) {
 
 	var configMap kafka.ConfigMap
 
@@ -82,24 +78,19 @@ func Producer(in chan []byte, config *ProducerConfig) {
 	defer p.Close()
 
 	for v := range in {
-		go func(v []byte) {
-			var s ServiceDef
-			err := json.Unmarshal(v, &s)
-			if err != nil {
-				l.Log.WithFields(logrus.Fields{"error": err, "topic": config.Topic}).Error("unable to gather service name for headers")
-			}
+		go func(v val.Transport) {
 			delivery_chan := make(chan kafka.Event)
 			defer close(delivery_chan)
 			producerCount.Inc()
 			defer producerCount.Dec()
 			start := time.Now()
 			p.Produce(&kafka.Message{
-				Headers: []kafka.Header{{Key: "service", Value: []byte(s.Service)}},
+				Headers: v.Headers,
 				TopicPartition: kafka.TopicPartition{
 					Topic:     &config.Topic,
 					Partition: kafka.PartitionAny,
 				},
-				Value: v,
+				Value: v.Message,
 			}, delivery_chan)
 			messagePublishElapsed.With(prom.Labels{"topic": config.Topic}).Observe(time.Since(start).Seconds())
 
@@ -108,7 +99,7 @@ func Producer(in chan []byte, config *ProducerConfig) {
 
 			if m.TopicPartition.Error != nil {
 				l.Log.WithFields(logrus.Fields{"error": m.TopicPartition.Error}).Error("Error publishing to kafka")
-				in <- m.Value
+				in <- v
 				publishFailures.With(prom.Labels{"topic": config.Topic}).Inc()
 				return
 			} else {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -84,11 +84,17 @@ func Producer(in chan validators.ValidationMessage, config *ProducerConfig) {
 			producerCount.Inc()
 			defer producerCount.Dec()
 			start := time.Now()
+			kafkaHeaders := make([]kafka.Header, len(v.Headers))
+			i := 0
+			for key, value := range v.Headers {
+				kafkaHeaders[i] = kafka.Header{
+					Key:   key,
+					Value: []byte(value),
+				}
+				i++
+			}
 			p.Produce(&kafka.Message{
-				Headers: []kafka.Header{{
-					Key: v.Headers["Key"],
-					Value: []byte(v.Headers["Value"]),
-				}},
+				Headers: kafkaHeaders,
 				TopicPartition: kafka.TopicPartition{
 					Topic:     &config.Topic,
 					Partition: kafka.PartitionAny,

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -45,6 +45,11 @@ type Config struct {
 	SASLMechanism   string
 }
 
+type IngestChannel struct {
+	Service string
+	Data chan []byte
+}
+
 // New constructs and initializes a new Kafka Validator
 func New(cfg *Config, topics ...string) *Validator {
 	kv := &Validator{
@@ -98,6 +103,7 @@ func (kv *Validator) Validate(vr *validators.Request) {
 	}
 	l.Log.WithFields(logrus.Fields{"data": data, "topic": realizedTopicName}).Debug("Posting data to topic")
 	kv.ValidationProducerMapping[realizedTopicName] <- data
+	kv.ValidationProducerMapping[config.Get().AnnounceTopic] <- data
 }
 
 func (kv *Validator) addProducer(topic string) {

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -72,6 +72,9 @@ func New(cfg *Config, topics ...string) *Validator {
 		kv.Protocol = cfg.Protocol
 	}
 
+	// ensure the announce topic is added and valid
+	topics = append(topics, "announce")
+
 	for _, topic := range topics {
 		var realizedTopicName string
 		topic = fmt.Sprintf("platform.upload.%s", topic)

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -45,11 +45,6 @@ type Config struct {
 	SASLMechanism   string
 }
 
-type IngestChannel struct {
-	Service string
-	Data chan []byte
-}
-
 // New constructs and initializes a new Kafka Validator
 func New(cfg *Config, topics ...string) *Validator {
 	kv := &Validator{

--- a/internal/validators/types.go
+++ b/internal/validators/types.go
@@ -2,8 +2,6 @@ package validators
 
 import (
 	"time"
-
-	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 )
 
 // Request is sent to the validation topic for each new payload
@@ -37,9 +35,9 @@ type Metadata struct {
 	StaleTimestamp time.Time `json:"stale_timestamp"`
 }
 
-type Transport struct {
-	Message []byte
-	Headers  []kafka.Header
+type ValidationMessage struct {
+	Message  []byte
+	Headers  map[string]string
 }
 
 // ServiceDescriptor is used to select a message topic

--- a/internal/validators/types.go
+++ b/internal/validators/types.go
@@ -2,6 +2,8 @@ package validators
 
 import (
 	"time"
+
+	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 )
 
 // Request is sent to the validation topic for each new payload
@@ -33,6 +35,11 @@ type Metadata struct {
 	AnsibleHost    string    `json:"ansible_host,omitempty"`
 	Reporter       string    `json:"reporter"`
 	StaleTimestamp time.Time `json:"stale_timestamp"`
+}
+
+type Transport struct {
+	Message []byte
+	Headers  []kafka.Header
 }
 
 // ServiceDescriptor is used to select a message topic


### PR DESCRIPTION
New uploads can be advertised on a single topic and the header can be
used if it is meant for a downstream service. This is meant to simplify
ingress code in the long run. It also allows services to onboard easier
by just sending data into the platform for it to be sorted at the client
level.

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
