### PR TITLE
Modify the way the kafka header keys are constructed

### DIFF
--- a/internal/announcers/kafka.go
+++ b/internal/announcers/kafka.go
@@ -56,10 +56,6 @@ func (k *Kafka) Status(vs *Status) {
 		l.Log.WithFields(logrus.Fields{"duration": time.Since(n)}).Debug("status announce")
 	}()
 	message := validators.ValidationMessage{
-		Headers: map[string]string{
-			"Key": "service",
-			"Value": vs.Service,
-		},
 		Message: data,
 	}
 	k.In <- message

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -103,8 +103,7 @@ func (kv *Validator) Validate(vr *validators.Request) {
 	message := validators.ValidationMessage{
 		Message: data,
 		Headers: map[string]string{
-			"Key": "service",
-			"Value": vr.Service,
+			"service": vr.Service,
 		},
 	}
 	kv.ValidationProducerMapping[realizedTopicName] <- message


### PR DESCRIPTION
This PR removes the headers for the message that gets sent to payload tracker.  I don't think payload tracker expects a header with the kafka messages.

This PR also changes the way the kafka headers are built for the single topic.  Currently, two headers are built, one has a key of "Key" and a value of "service", the other has a key of "Value" with a value of the name of the service that should handle the message.  This requires the consumers to look for both headers to determine if it is a message that they should handle.  This PR changes it so that there is a single header with the key as  "service" and the value is the name of the service that should handle the message.

I might be misunderstanding the way the headers are used here.  If so, feel free to ignore this PR.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
