### PR TITLE
Config cleanup

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -12,7 +12,6 @@ import (
 	"github.com/redhatinsights/insights-ingress-go/internal/config"
 	lc "github.com/redhatinsights/platform-go-middlewares/logging/cloudwatch"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // Log is an instance of the global logrus.Logger
@@ -89,19 +88,14 @@ func (f *CustomCloudwatch) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 // InitLogger initializes the Entitlements API logger
-func InitLogger() *logrus.Logger {
-
-	cfg := config.Get()
-	logconfig := viper.New()
-	key := cfg.AwsAccessKeyId
-	secret := cfg.AwsSecretAccessKey
-	region := cfg.AwsRegion
-	group := cfg.LogGroup
+func InitLogger(cfg *config.IngressConfig) *logrus.Logger {
+	key := cfg.LoggingConfig.AwsAccessKeyId
+	secret := cfg.LoggingConfig.AwsSecretAccessKey
+	region := cfg.LoggingConfig.AwsRegion
+	group := cfg.LoggingConfig.LogGroup
 	stream := cfg.Hostname
-	logconfig.SetEnvPrefix("INGRESS")
-	logconfig.AutomaticEnv()
 
-	switch cfg.LogLevel {
+	switch cfg.LoggingConfig.LogLevel {
 	case "DEBUG":
 		logLevel = logrus.DebugLevel
 	case "ERROR":

--- a/internal/stage/s3compat/s3compat.go
+++ b/internal/stage/s3compat/s3compat.go
@@ -16,16 +16,16 @@ type Stager struct {
 }
 
 // GetClient gets the s3 compatible client info
-func GetClient(stager *Stager) stage.Stager {
+func GetClient(cfg *config.IngressConfig, stager *Stager) stage.Stager {
 	var endpoint string
-	if config.Get().StorageEndpoint == "" {
+	if cfg.StorageConfig.StorageEndpoint == "" {
 		endpoint = "s3.amazonaws.com"
 	} else {
-		endpoint = config.Get().StorageEndpoint
+		endpoint = cfg.StorageConfig.StorageEndpoint
 	}
-	accessKeyID := config.Get().StorageAccessKey
-	secretAccessKey := config.Get().StorageSecretKey
-	useSSL := config.Get().UseSSL
+	accessKeyID := cfg.StorageConfig.StorageAccessKey
+	secretAccessKey := cfg.StorageConfig.StorageSecretKey
+	useSSL := cfg.StorageConfig.UseSSL
 
 	stager.Client, _ = minio.New(endpoint, accessKeyID, secretAccessKey, useSSL)
 

--- a/internal/track/track_suite_test.go
+++ b/internal/track/track_suite_test.go
@@ -5,11 +5,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/insights-ingress-go/internal/config"
 	l "github.com/redhatinsights/insights-ingress-go/internal/logger"
 )
 
 func TestTrack(t *testing.T) {
+	cfg := config.Get()
 	RegisterFailHandler(Fail)
-	l.InitLogger()
+	l.InitLogger(cfg)
 	RunSpecs(t, "Track Suite")
 }

--- a/internal/upload/upload_suite_test.go
+++ b/internal/upload/upload_suite_test.go
@@ -5,11 +5,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/insights-ingress-go/internal/config"
 	l "github.com/redhatinsights/insights-ingress-go/internal/logger"
 )
 
 func TestUpload(t *testing.T) {
+	cfg := config.Get()
 	RegisterFailHandler(Fail)
-	l.InitLogger()
+	l.InitLogger(cfg)
 	RunSpecs(t, "Upload Suite")
 }

--- a/internal/validators/kafka/kafka_suite_test.go
+++ b/internal/validators/kafka/kafka_suite_test.go
@@ -5,11 +5,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/insights-ingress-go/internal/config"
 	l "github.com/redhatinsights/insights-ingress-go/internal/logger"
 )
 
 func TestKafka(t *testing.T) {
+	cfg := config.Get()
 	RegisterFailHandler(Fail)
-	l.InitLogger()
+	l.InitLogger(cfg)
 	RunSpecs(t, "Kafka Suite")
 }

--- a/internal/validators/kafka/kafka_test.go
+++ b/internal/validators/kafka/kafka_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Kafka", func() {
 					Service:  "unknown",
 					Category: "test",
 				})
-				Expect(err.Error()).To(Equal("Validation topic is invalid"))
+				Expect(err.Error()).To(Equal("Validation topic is invalid: unknown"))
 			})
 		})
 	})

--- a/internal/version/version_suite_test.go
+++ b/internal/version/version_suite_test.go
@@ -6,11 +6,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/redhatinsights/insights-ingress-go/internal/config"
 	l "github.com/redhatinsights/insights-ingress-go/internal/logger"
 )
 
 func TestInventory(t *testing.T) {
+	cfg := config.Get()
 	RegisterFailHandler(Fail)
-	l.InitLogger()
+	l.InitLogger(cfg)
 	RunSpecs(t, "Version Suite")
 }


### PR DESCRIPTION
This one is all about making the config a little bit more compartmentalized. Nothing significantly changed in terms of the values being used, but I did change up the struct a bit.

I also removed the multiple calls to `config.Get()` and instead passed the config along as arguments to those functions that needed it. `InitLogger()` for example is now `InitLogger(cfg *config.IngressConfig)`


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
