### PR TITLE
Add missing closing brackets in paths section of spec

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -118,8 +118,10 @@
             "default": 0,
             "minimum": 0,
             "maximum": 2
-        }
-      ]
+          }
+        ]
+      }
+    }
   },
   "components": {
     "schemas": {


### PR DESCRIPTION
I was notified that this OpenAPI spec was failing basic validation and found what I believer are the correct missing closing brackets.

Fixes the first part of https://issues.redhat.com/browse/RHCLOUD-17102

Running [openapi-spec-validator](https://github.com/p1c2u/openapi-spec-validator#usage) resulted in the following:
```yaml
openapi-spec-validator ./api/openapi.json

while parsing a flow mapping
  in "/Users/gmccullo/work/Insights/insights-ingress-go/api/openapi.json", line 14, column 12
expected ',' or '}', but got '<stream end>'
  in "/Users/gmccullo/work/Insights/insights-ingress-go/api/openapi.json", line 217, column 2
```

After these changes the format of the JSON is valid but there are OpenAPI validation issues that will still need to be addressed in a followup PR.

```yaml
openapi-spec-validator ./api/openapi.json

{'description': 'Advisor content type with no metadata accepted for processing', 'content': {'application/json': {'schema': {'request_id': {'type': 'string'}}}}} is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['paths']['patternProperties']['^\\/']['patternProperties']['^(get|put|post|delete|options|head|patch|trace)$']['properties']['responses']['patternProperties']['^[1-5](?:\\d{2}|XX)$']:
    {'oneOf': [{'$ref': '#/definitions/Response'},
               {'$ref': '#/definitions/Reference'}]}

On instance['paths']['/upload']['post']['responses']['201']:
    {'content': {'application/json': {'schema': {'request_id': {'type': 'string'}}}},
     'description': 'Advisor content type with no metadata accepted for '
                    'processing'}
```

cc @jharting 