### PR TITLE
[task] Add content_type to kafka messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Validation Messages:
        {
            "account": <account number>,
            "category": <currently translates to filename>,
+           "content_type": <full content type string from the client>,
            "request_id": <uuid for the payload>,
            "principal": <currently the org ID>,
            "service": <service the upload goes to>,

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -191,6 +191,7 @@ func NewHandler(
 			Service:     serviceDescriptor.Service,
 			Category:    serviceDescriptor.Category,
 			B64Identity: b64Identity,
+			ContentType: contentType,
 		}
 
 		var exceedsSizeLimit bool

--- a/internal/validators/types.go
+++ b/internal/validators/types.go
@@ -8,6 +8,7 @@ import (
 type Request struct {
 	Account     string    `json:"account"`
 	Category    string    `json:"category"`
+	ContentType string    `json:"content_type"`
 	Metadata    Metadata  `json:"metadata"`
 	RequestID   string    `json:"request_id"`
 	Principal   string    `json:"principal"`


### PR DESCRIPTION
This will contain the string for the content type so that apps can use
the full string if they need it



## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices