### PR TITLE
[task] add latest image to quay when built

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -23,3 +23,5 @@ docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
 docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
 docker --config="$DOCKER_CONF" push "${IMAGE}:qa"
+docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
+docker --config="$DOCKER_CONF" push "${IMAGE}:latest"


### PR DESCRIPTION
The current quay repo doesn't contain a recent latest image. We had stopped
pushing this a while back, and we need to put it back. This change will just tag
the most recent image as the latest.


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices