### PR TITLE
[build] set the builder image to the latest go-toolset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/go-toolset:1.16.7 as builder
+FROM registry.redhat.io/ubi8/go-toolset:latest as builder
 
 WORKDIR /go/src/app
 COPY . .


### PR DESCRIPTION
In order to get the latest features from minor releases of go 1.16, and
to ensure we get security fixes, we're setting this to be the latest
tag.

RHCLOUD-17485



## What?
Set the go-toolset builder image in the Dockerfile to the latest tag.

## Why?
When fixes are added to the go-toolset image, it won't be updated unless we grab the latest version of it.

## How?
Simply changed the tag in the dockerfile

## Testing
No additional testing is required

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [x] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices