### PR TITLE
Add org id to upload response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.17.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/redhatinsights/app-common-go v1.6.0
-	github.com/redhatinsights/platform-go-middlewares v0.10.0
+	github.com/redhatinsights/platform-go-middlewares v0.11.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.9.0
 	gopkg.in/confluentinc/confluent-kafka-go.v1 v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,8 @@ github.com/redhatinsights/app-common-go v1.6.0 h1:7ZW7dIVY3n9UImfoduG9wR7Tgiw3zy
 github.com/redhatinsights/app-common-go v1.6.0/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
 github.com/redhatinsights/platform-go-middlewares v0.10.0 h1:VVuWvPL7xHYnmVMz6jK9lUqyPc1vOEWdpo6eVu7e9iQ=
 github.com/redhatinsights/platform-go-middlewares v0.10.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
+github.com/redhatinsights/platform-go-middlewares v0.11.0 h1:NRCnBIlXRGI3cKEDeiHsXbOUAVcPQZ3vnt4EVlcFKVQ=
+github.com/redhatinsights/platform-go-middlewares v0.11.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -140,6 +140,10 @@
                         "properties": {
                             "account": {
                                 "type": "string"
+                            },
+                            "org_id": {
+                                "type": "string",
+                                "description": "Oracle account number which is a unique identifier for a customer account"
                             }
                         }
                     }

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -143,7 +143,7 @@
                             },
                             "org_id": {
                                 "type": "string",
-                                "description": "Oracle account number which is a unique identifier for a customer account"
+                                "description": "Tennant customer identifier used by front office systems (SSO, RHSM, Customer Portal)"
                             }
                         }
                     }

--- a/internal/validators/types.go
+++ b/internal/validators/types.go
@@ -12,6 +12,7 @@ type Request struct {
 	Metadata    Metadata  `json:"metadata"`
 	RequestID   string    `json:"request_id"`
 	Principal   string    `json:"principal"`
+	OrgID       string    `json:"org_id"`
 	Service     string    `json:"service"`
 	Size        int64     `json:"size"`
 	URL         string    `json:"url"`


### PR DESCRIPTION
## What?
Added org_id field to the upload response body.

## Why?
This is the next step with the EBS account number swap to the org id for the ingress service.

## How?
Added org id to the upload response by adding the Org_ID or "principal" field to the upload response model.

## Testing
Added automated testing around the addition of the org_id to the upload-response.

## Anything Else?
JIRA:  https://issues.redhat.com/browse/RHCLOUD-17860

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
