### PR TITLE
Better healthcheck

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type KafkaCfg struct {
 	KafkaAnnounceTopic   string
 	ValidTopics          []string
 	KafkaSSLConfig	     KafkaSSLCfg
+	KafkaLoadWaitTime	 int
 }
 
 type KafkaSSLCfg struct {
@@ -84,6 +85,7 @@ func Get() *IngressConfig {
 	options.SetDefault("KafkaDeliveryReports", true)
 	options.SetDefault("KafkaTrackerTopic", "platform.payload-status")
 	options.SetDefault("KafakAnnounceTopic", "platform.upload.announce")
+	options.SetDefault("KafkaLoadWaitTime", 1)
 
 	// Global defaults
 	options.SetDefault("MaxUploadMem", 1024*1024*8)
@@ -179,7 +181,8 @@ func Get() *IngressConfig {
 			KafkaTrackerTopic:    options.GetString("KafkaTrackerTopic"),
 			KafkaDeliveryReports: options.GetBool("KafkaDeliveryReports"),
 			KafkaAnnounceTopic:   options.GetString("KafakAnnounceTopic"),
-			ValidTopics: 		  strings.Split(options.GetString("ValidTopics"), ","),
+			ValidTopics: 		  strings.Split(options.GetString("ValidTopics"), ","), 
+			KafkaLoadWaitTime:    options.GetInt("KafkaLoadWaitTime"),
 		},
 		StorageConfig: StorageCfg{
 			StageBucket: options.GetString("StageBucket"),

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -298,7 +298,9 @@ func NewHandler(
 		requestLogger.WithFields(logrus.Fields{"service": vr.Service}).Info("Payload sent to validation service")
 		tracker.Status(ps)
 
-		validator.Validate(vr)
+		if !validator.Validate(vr) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
 
 		jsonBody, err := createUploadResponse(vr)
 		if err != nil {

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Upload", func() {
 	BeforeEach(func() {
 
 		stager = &stage.Fake{ShouldError: false}
-		validator = &validators.Fake{}
+		validator = &validators.Fake{BufferResponse: true}
 		tracker = &announcers.Fake{}
 
 		rr = httptest.NewRecorder()
@@ -385,6 +385,18 @@ var _ = Describe("Upload", func() {
 				stager = &stage.Fake{ShouldError: true}
 				handler = NewHandler(stager, validator, tracker, *config.Get())
 				boiler(http.StatusInternalServerError, &FilePart{
+					Name:        "file",
+					Content:     "testing",
+					ContentType: "application/vnd.redhat.unit.test",
+				})
+			})
+		})
+		
+		Context("when we fail to write to the bufferr", func() {
+			It("should return a 503", func() {
+				validator = &validators.Fake{BufferResponse: false}
+				handler = NewHandler(stager, validator, tracker, *config.Get())
+				boiler(http.StatusServiceUnavailable, &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test",

--- a/internal/validators/fake.go
+++ b/internal/validators/fake.go
@@ -8,11 +8,13 @@ import (
 type Fake struct {
 	In     *Request
 	Called bool
+	BufferResponse bool
 }
 
-func (v *Fake) Validate(in *Request) {
+func (v *Fake) Validate(in *Request) bool {
 	v.Called = true
 	v.In = in
+	return v.BufferResponse
 }
 
 // ValidateService allows for testing service validations

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -122,7 +122,7 @@ func (kv *Validator) Validate(vr *validators.Request) bool {
 	// then we can send the proper status code that our buffer is full.
 	select {
 	case <- kv.Load(message, realizedTopicName):
-		l.Log.WithFields(logrus.Fields{"topic": realizedTopicName}).Debug("Message loaded to buffer for publishing")
+		l.Log.WithFields(logrus.Fields{"topic": realizedTopicName, "request_id": vr.RequestID}).Debug("Message loaded to buffer for publishing")
 		return true
 	case <- time.After(time.Duration(config.Get().KafkaConfig.KafkaLoadWaitTime) * time.Second):
 		l.Log.WithFields(logrus.Fields{"topic": realizedTopicName, "request_id": vr.RequestID}).Error("Buffer is full, waiting for space")

--- a/internal/validators/types.go
+++ b/internal/validators/types.go
@@ -51,6 +51,6 @@ type ServiceDescriptor struct {
 
 // Validator validates requests
 type Validator interface {
-	Validate(req *Request)
+	Validate(req *Request) bool
 	ValidateService(service *ServiceDescriptor) error
 }


### PR DESCRIPTION
## What?
This change makes it so that we pass along the proper HTTP error code if our local buffer is full. When this happens, we cannot properly store user data for publishing to kafka. In this case, we won't queue up messages if the buffer is full and we'll send a 503 error to the client

RHCLOUD-4852

## Why?
Customers could be told that their record is created, but data loss could happen causing the message to be lost. This could be a confusing interaction. 

## How?
Reworked the validator to respond with a boolean based on whether the channel could accept a new message or not. Used a select statement that pits the buffer loading operation against a configurable timer. If the timer completes first, we fail the message. The only way this happens is if we error out when loading up the buffer with data.

## Testing
Added an automated test for the 503

## Anything Else?
This is another draft of an idea, so open to suggestions.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
