### PR TITLE
[task] update middlewares go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.17.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/redhatinsights/app-common-go v1.6.0
-	github.com/redhatinsights/platform-go-middlewares v0.11.0
+	github.com/redhatinsights/platform-go-middlewares v0.12.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.9.0
 	gopkg.in/confluentinc/confluent-kafka-go.v1 v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,8 @@ github.com/redhatinsights/platform-go-middlewares v0.10.0 h1:VVuWvPL7xHYnmVMz6jK
 github.com/redhatinsights/platform-go-middlewares v0.10.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/redhatinsights/platform-go-middlewares v0.11.0 h1:NRCnBIlXRGI3cKEDeiHsXbOUAVcPQZ3vnt4EVlcFKVQ=
 github.com/redhatinsights/platform-go-middlewares v0.11.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
+github.com/redhatinsights/platform-go-middlewares v0.12.0 h1:gLFgsqupumRqAKDuYtvrYVNQr53iqfhQYc98VJ/cRUs=
+github.com/redhatinsights/platform-go-middlewares v0.12.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=


### PR DESCRIPTION
for org_id fallback support

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
We need to update to the latest go middlewares package in order to support fallback for org_id in the event we get a header in the wrong place.

## Why?
Things will break if they aren't properly moved to the top level. This handles that issue.

## How?
Update platform-go-middlewares

## Testing
external mod update

## Anything Else?
https://www.github.com/RedHatInsights/platform-go-middlwares

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
