### PR TITLE
[docs] Add operator archive flow to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ The Ingress workflow is as follows:
   cloud storage, and puts a message on the announcement topic while applying a header
   to identify the destination service.
 
+For the vast majority of topics, the above process is accurate. For payloads from both
+**ansible tower** and the **insights cluster operator**, the flow is a bit different. The key difference here is that it relies on the UHC Auth Proxy for authentication.
+
+![UML](https://www.plantuml.com/plantuml/png/TP5FSvim4CNl-HHRNzBEDEP0Jpt5mTF6qwRrXFYSMSC6D0Y9QbTntKzV2Mpe4FV4_dc_vV6uPK4dljLNxvGfj2y9Qf6EFoU9myEoKbBxlMToXJL2HfQ5RPDEeudC3KkfrJx9FjriusZty3rfaOLS63rdWK1bo2sxUFygFuPD-pwy92e-mY8RgaKeDuPLLGl3puuSYdMB3sSzDjYY2ffLNqHrjlunxLCkK5EOfdaiudwrtS1N53hWSTBvkWYhtNq6AoyrR9tzVOpYs94HLQ0eQo0dzweAcZXbAaVCqUHGHMZNQOlbMp6BTLZHdRDD_udvqCCmY6IUdfeBSDhlUrCj_h46xhGj6ZWVcO17qbEEOq23gTxV_TFJDX-4puzZX6DKNwmxe2jXZqmbM0Daoiug8pDs33U6Duzg9Xbp6g-BFG-11-lpyoF3wHHgXyVuZ3WBLa43Uryq9F-dvwcJAQ4Dgp2CPzx-XM_uqk3fp8pkhJpOL_hNoBLrrMQTd38FbQDVdbWswsjG1cn7Xclr8XUStWOpljL_0G00)
+
 ### Kafka Topics (Legacy)
 
 Ingress produces to topics to alert services of a new upload. The first topic an

--- a/sequencebuckit.puml
+++ b/sequencebuckit.puml
@@ -1,0 +1,18 @@
+@startuml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+
+System(cluster, "Cluster", "Insights Operator")
+System(akamai, "Akamai", "CDN")
+System(3scale, "3Scale", "API Gateway")
+System(uhc, "UHC Auth Proxy", "Authentication Service")
+System(ingress, "Ingress", "Upload Service")
+System(storageBroker, "Storage Broker", "S3 Broker Service")
+System(s3, "S3", "Amazon Block Storage Service")
+Rel(cluster, akamai, "Uploads", "HTTPS")
+Rel_R(akamai, 3scale, "Forward based on endpoint", "HTTPS")
+Rel(3scale, uhc, "Authentication")
+Rel(3scale, ingress, "Forward to ingress service", "HTTPS")
+Rel(ingress, s3, "Upload payload to staging bucket", "HTTPS")
+Rel(ingress, storageBroker, "Send message to Storage Broker", "Kafka")
+Rel(storageBroker, s3, "Move payload to 'orgID/clusterID/requestID' in openshift bucket", "HTTPS")
+@enduml


### PR DESCRIPTION
Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Add details to the readme regarding the pipeline as used by CCX and ansible Tower

## Why?
We didn't have this documented before and it made it difficult for the CCX team to discern areas of interest during troubleshooting.

## How?
Added a sequence diagram and some details for the traffic flow.

## Testing
n/a

## Anything Else?
n/a

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
