### PR TITLE
Add a new response type for the /track endpoint

### DIFF
--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -112,7 +112,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/TrackResponse"
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/TrackResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/TrackResponseFull"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -166,6 +173,58 @@
                     },
                     "status": {
                         "type": "string"
+                    }
+                }
+            },
+            "TrackResponseFull": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "service": {
+                                    "type": "string"
+                                },
+                                "source": {
+                                    "type": "string"
+                                },
+                                "account": {
+                                    "type": "string"
+                                },
+                                "org_id": {
+                                    "type": "string"
+                                },
+                                "request_id": {
+                                    "type": "string"
+                                },
+                                "inventory_id": {
+                                    "type": "string"
+                                },
+                                "system_id": {
+                                    "type": "string"
+                                },
+                                "created_at": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "string"
+                                },
+                                "status_msg": {
+                                    "type": "string"
+                                },
+                                "date": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "duration": {
+                        "type": "object"
                     }
                 }
             }


### PR DESCRIPTION
## What?
The /track endpoint can return 2 types of response payloads based on the verbosity specified in the request. This change adds the missing response type in the OpenAPI specification.

## Why?
To allow IQE to be able to generate the OpenAPI python client based on the specification.

## How?
Adding a new response type to the OpenAPI spec.

## Testing


## Anything Else?


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
