### PR TITLE
[feat] Add ability for QE to use certs in track endpoint

### DIFF
--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -2,9 +2,11 @@ package track
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi"
 	"github.com/redhatinsights/insights-ingress-go/internal/config"
@@ -81,7 +83,14 @@ func NewHandler(
 			return
 		}
 
-		if id.Identity.Type != "Associate" {
+		var subjectDN string
+		if id.Identity.X509.SubjectDN != "" {
+			subjectSplit := strings.Split(id.Identity.X509.SubjectDN, "=")
+			subjectDN = subjectSplit[len(subjectSplit)-1]
+		}
+		fmt.Print(id.Identity.Type)
+		fmt.Print(subjectDN)
+		if id.Identity.Type != "Associate" && subjectDN != "insightspipelineqe" {
 			if pt.Data[0].Account != id.Identity.AccountNumber {
 				w.WriteHeader(http.StatusForbidden)
 				return

--- a/internal/track/track_test.go
+++ b/internal/track/track_test.go
@@ -41,6 +41,15 @@ func makeTestRequest(uri string, request_id string, account string, account_type
 				Type: "Associate",
 			},
 		})
+	case "x509":
+		ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
+			Identity: identity.Identity{
+				X509: identity.X509{
+					SubjectDN: "/DC=com/DC=redhat/CN=insightspipelineqe",
+					IssuerDN: "CN=redhat",
+				},
+			},
+		})
 	default:
 		ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
 			Identity: identity.Identity{
@@ -124,6 +133,18 @@ var _ = Describe("Track", func() {
 			It("should return HTTP 200", func() {
 				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
 				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "associate")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(200))
+				Expect(rr.Body).ToNot(BeNil())
+				Expect(rr.Body.String()).To(Equal(minimalJsonBody))
+			})
+		})
+
+		Context("with a qe test account", func() {
+			It("should return HTTP 200", func() {
+				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "x509")
 				Expect(err).To(BeNil())
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(200))


### PR DESCRIPTION
The tracking endpoint needs to be setup in order for QE to use an x509
cert to do their testing when tracking payloads.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Add support for the QE turnpike cert

## Why?
The QE team occasionally needs to find tracking payloads that they did not upload from their own account. This will allow them to use a cert to track these payloads as an "associate"

## How?
Added a check for teh X509 cert and make sure that it belongs to insightspipelineqe by checking the IssuerDN

## Testing
A test has been added

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
