### PR TITLE
[deps] Update to platform-go-middlewares 0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.34.0 // indirect
 	github.com/redhatinsights/app-common-go v1.6.1
-	github.com/redhatinsights/platform-go-middlewares v0.16.1
+	github.com/redhatinsights/platform-go-middlewares v0.17.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.11.0
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f // indirect

--- a/go.sum
+++ b/go.sum
@@ -399,6 +399,8 @@ github.com/redhatinsights/platform-go-middlewares v0.16.0 h1:ba8jE/Ust6fnTD6PbM3
 github.com/redhatinsights/platform-go-middlewares v0.16.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/redhatinsights/platform-go-middlewares v0.16.1 h1:ZWVv0CiAH3S8ir736PpeIJAnvngxILvphEvW2nBVOzc=
 github.com/redhatinsights/platform-go-middlewares v0.16.1/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
+github.com/redhatinsights/platform-go-middlewares v0.17.0 h1:upjyS2Fq+yGio0N8TrZWha6ZzhidIkRROM0QnDqpiMk=
+github.com/redhatinsights/platform-go-middlewares v0.17.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=


### PR DESCRIPTION
This change allows the use of the x509 cert for turnpike integration.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Update middlewares to version 0.17.0

## Why?
This allows the use of an X509 cert when coming through turnpike

## How?
Update in go.mod and go.sum

## Testing
Tests are performed in the middlewares repo

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
