### PR TITLE
Rhcloud 19141 allow org id track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 insights-ingress-go
+insights-ingress
 .idea
 coverage.txt
 .scannerwork

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -91,7 +91,7 @@ func NewHandler(
 		fmt.Print(id.Identity.Type)
 		fmt.Print(subjectDN)
 		if id.Identity.Type != "Associate" && subjectDN != "insightspipelineqe" {
-			if pt.Data[0].Account != id.Identity.AccountNumber {
+			if !isIdAuthorized(id.Identity, pt.Data[0].Account, pt.Data[0].OrgID) {
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}
@@ -120,4 +120,8 @@ func NewHandler(
 			w.Write(responseBody)
 		}
 	}
+}
+
+func isIdAuthorized(identity identity.Identity, accountNumber string, orgID string) bool {
+	return identity.AccountNumber == accountNumber || identity.OrgID == orgID
 }

--- a/internal/track/track_test.go
+++ b/internal/track/track_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/redhatinsights/insights-ingress-go/internal/track"
 )
 
-func makeTestRequest(uri string, request_id string, account string, account_type string) (*http.Request, error) {
+func makeTestRequest(uri string, request_id string, account string, orgID string, account_type string) (*http.Request, error) {
 
 	var req *http.Request
 	var err error
@@ -36,7 +36,7 @@ func makeTestRequest(uri string, request_id string, account string, account_type
 			Identity: identity.Identity{
 				AccountNumber: account,
 				Internal: identity.Internal{
-					OrgID: "12345",
+					OrgID: orgID,
 				},
 				Type: "Associate",
 			},
@@ -46,7 +46,7 @@ func makeTestRequest(uri string, request_id string, account string, account_type
 			Identity: identity.Identity{
 				X509: identity.X509{
 					SubjectDN: "/DC=com/DC=redhat/CN=insightspipelineqe",
-					IssuerDN: "CN=redhat",
+					IssuerDN:  "CN=redhat",
 				},
 			},
 		})
@@ -54,8 +54,9 @@ func makeTestRequest(uri string, request_id string, account string, account_type
 		ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
 			Identity: identity.Identity{
 				AccountNumber: account,
+				OrgID:         orgID,
 				Internal: identity.Internal{
-					OrgID: "12345",
+					OrgID: orgID,
 				},
 			},
 		})
@@ -72,7 +73,7 @@ var _ = Describe("Track", func() {
 	var (
 		handler         http.Handler
 		rr              *httptest.ResponseRecorder
-		goodJsonBody    = `{"data":[{"id":7738152,"status_msg":"message received","date":"2021-06-11 20:12:40.228334+00:00","created_at":"2021-06-11 20:12:40.375706+00:00","request_id":"747c1300667b441e8e8f448337588ec0","account":"6089719","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","system_id":"b1596dc8-fb46-4e16-8790-d11ea7dfa16a","service":"inventory-mq-service","status":"received"},{"id":7738150,"status_msg":"Message sent to inventory","date":"2021-06-11 20:12:40.212302+00:00","created_at":"2021-06-11 20:12:40.269223+00:00","request_id":"747c1300667b441e8e8f448337588ec0","account":"6089719","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","system_id":"b1596dc8-fb46-4e16-8790-d11ea7dfa16a","service":"puptoo","status":"success"},{"id":7738149,"status_msg":"Received message","date":"2021-06-11 20:12:39.219543+00:00","created_at":"2021-06-11 20:12:39.303714+00:00","request_id":"747c1300667b441e8e8f448337588ec0","account":"6089719","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","system_id":"b1596dc8-fb46-4e16-8790-d11ea7dfa16a","service":"puptoo","status":"received"}],"duration":{"hsp-archiver:undefined":"0:00:00.067749","storage-broker:undefined":"0:00:00","puptoo:undefined":"0:00:00.992759","inventory-mq-service:undefined":"0:00:00.102472","vulnerability-rules:undefined":"0:00:01.155458","insights-engine:undefined":"0:00:01.691324","vulnerability-vmaas:undefined":"0:00:02.812779","insights-advisor-service:insights-client":"0:00:00.066972","total_time_in_services":"0:00:06.889513","total_time":"0:00:04.038974"}}`
+		goodJsonBody    = `{"data":[{"id":7738152,"status_msg":"message received","date":"2021-06-11 20:12:40.228334+00:00","created_at":"2021-06-11 20:12:40.375706+00:00","request_id":"747c1300667b441e8e8f448337588ec0","account":"6089719","org_id":"12345","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","system_id":"b1596dc8-fb46-4e16-8790-d11ea7dfa16a","service":"inventory-mq-service","status":"received"},{"id":7738150,"status_msg":"Message sent to inventory","date":"2021-06-11 20:12:40.212302+00:00","created_at":"2021-06-11 20:12:40.269223+00:00","request_id":"747c1300667b441e8e8f448337588ec0","account":"6089719","org_id":"12345","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","system_id":"b1596dc8-fb46-4e16-8790-d11ea7dfa16a","service":"puptoo","status":"success"},{"id":7738149,"status_msg":"Received message","date":"2021-06-11 20:12:39.219543+00:00","created_at":"2021-06-11 20:12:39.303714+00:00","request_id":"747c1300667b441e8e8f448337588ec0","account":"6089719","org_id":"12345","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","system_id":"b1596dc8-fb46-4e16-8790-d11ea7dfa16a","service":"puptoo","status":"received"}],"duration":{"hsp-archiver:undefined":"0:00:00.067749","storage-broker:undefined":"0:00:00","puptoo:undefined":"0:00:00.992759","inventory-mq-service:undefined":"0:00:00.102472","vulnerability-rules:undefined":"0:00:01.155458","insights-engine:undefined":"0:00:01.691324","vulnerability-vmaas:undefined":"0:00:02.812779","insights-advisor-service:insights-client":"0:00:00.066972","total_time_in_services":"0:00:06.889513","total_time":"0:00:04.038974"}}`
 		minimalJsonBody = `{"status_msg":"message received","date":"2021-06-11 20:12:40.228334+00:00","inventory_id":"766637dd-653f-4bf0-99a1-a117b455cd96","service":"inventory-mq-service","status":"received"}`
 		badJsonID       = `{"data": [], "duration": {}}`
 	)
@@ -88,7 +89,7 @@ var _ = Describe("Track", func() {
 		Context("with a valid request-id", func() {
 			It("should return HTTP 200", func() {
 				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
-				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089719", "customer")
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089719", "12345", "customer")
 				Expect(err).To(BeNil())
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(200))
@@ -97,10 +98,10 @@ var _ = Describe("Track", func() {
 			})
 		})
 
-		Context("with a valid request-id and higher verbisity", func() {
+		Context("with a valid request-id and higher verbosity", func() {
 			It("should return HTTP 200", func() {
 				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
-				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2?verbosity=2", "3e3f56e642a248008811cce123b2c0f2", "6089719", "customer")
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2?verbosity=2", "3e3f56e642a248008811cce123b2c0f2", "6089719", "12345", "customer")
 				Expect(err).To(BeNil())
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(200))
@@ -109,20 +110,40 @@ var _ = Describe("Track", func() {
 			})
 		})
 
+		Context("with an incorrect account but valid orgID", func() {
+			It("should return an HTTP 200", func() {
+				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "", "12345", "customer")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(200))
+			})
+		})
+
+		Context("with an incorrect orgID but valid account", func() {
+			It("should return an HTTP 200", func() {
+				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089719", "12346", "customer")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(200))
+			})
+		})
+
 		Context("with an invalid request-id", func() {
 			It("should return HTTP 404", func() {
 				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, badJsonID))
-				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089719", "customer")
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089719", "12345", "customer")
 				Expect(err).To(BeNil())
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(404))
 			})
 		})
 
-		Context("with an incorrect account", func() {
+		Context("with an incorrect account and orgID", func() {
 			It("should return an HTTP 403", func() {
 				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
-				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "customer")
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "12346", "customer")
 				Expect(err).To(BeNil())
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(403))
@@ -132,7 +153,7 @@ var _ = Describe("Track", func() {
 		Context("with an associate login", func() {
 			It("should return HTTP 200", func() {
 				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
-				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "associate")
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "12346", "associate")
 				Expect(err).To(BeNil())
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(200))
@@ -144,7 +165,7 @@ var _ = Describe("Track", func() {
 		Context("with a qe test account", func() {
 			It("should return HTTP 200", func() {
 				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
-				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "x509")
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "12346", "x509")
 				Expect(err).To(BeNil())
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(200))


### PR DESCRIPTION
## What?
[RHCLOUD-19141](https://issues.redhat.com/browse/RHCLOUD-19141)
Update ingress track endpoint to allow requests with orgID to match on payloads retrieved from payload tracker.
Also, deleted executable that was committed to the root dir.

## Why?
Since we are moving to orgID as tenant identifier, we want to be able to support both account and orgID in the track endpoint.

## How?
Added a check for orgID when validating user is authorized to retrieve payloads.

## Testing
Added unit tests to cover changes, tested endpoint manually locally

## Anything Else?
N/A

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
