### PR TITLE
[sasl] update sasl configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.34.0 // indirect
-	github.com/redhatinsights/app-common-go v1.6.1
+	github.com/redhatinsights/app-common-go v1.6.2
 	github.com/redhatinsights/platform-go-middlewares v0.17.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,8 @@ github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/redhatinsights/app-common-go v1.6.1 h1:yYobGMfkprkpUuYxNetzaJUo7m1ikaYMkL0J5Z4lRlY=
 github.com/redhatinsights/app-common-go v1.6.1/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
+github.com/redhatinsights/app-common-go v1.6.2 h1:SYOYC7eelAAMiOK8hp4GxmQLAJ4HtuJ50kNzEZa7S/4=
+github.com/redhatinsights/app-common-go v1.6.2/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
 github.com/redhatinsights/platform-go-middlewares v0.14.0 h1:J7D/4ScOVknr74bfZaeN8zbNWfDhqdJw0IYAyG9xJhc=
 github.com/redhatinsights/platform-go-middlewares v0.14.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/redhatinsights/platform-go-middlewares v0.15.0 h1:o7VBiX3BRN6WoyAQlKuPqgPqq4qx0Uzd7j+eaMGHz30=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,8 +124,8 @@ func Get() *IngressConfig {
 		if broker.Authtype != nil {
 			options.Set("KafkaUsername", *broker.Sasl.Username)
 			options.Set("KafkaPassword", *broker.Sasl.Password)
-			options.Set("SASLMechanism", "SCRAM-SHA-512")
-			options.Set("Protocol", "sasl_ssl")
+			options.Set("SASLMechanism", *broker.Sasl.SaslMechanism)
+			options.Set("Protocol", *broker.Sasl.SecurityProtocol)
 			caPath, err := cfg.KafkaCa(broker)
 			if err != nil {
 				panic("Kafka CA failed to write")


### PR DESCRIPTION
We needed the latest version of app-common-go in order to pull sasl
configs from clowder. This is necessary for SSL kafka

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Pull sasl configs from clowder

## Why?
The fedramp cluster and managed kafka system use SASL for kafka clients. They each use a different mechanism, so we have to find a way to provide it. Now clowder provides the data, so we'll just leverage that in the config.

## How?
Just update the config to pull info from clowder.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
