### PR TITLE
Use ubi8 latest image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go get -d ./... && \
 
 RUN cp /go/src/app/insights-ingress-go /usr/bin/
 
-FROM registry.redhat.io/ubi8/ubi-minimal:8.5
+FROM registry.redhat.io/ubi8/ubi-minimal:latest
 
 WORKDIR /
 


### PR DESCRIPTION
Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Update the dockerfile to pull latest ubi8-minimal image

## Why?
We should generally be getting the latest security updates and packages. Locking at a particular version could cause is to miss those.

## How?
Just update the FROM field for the running image

## Testing
I built and ran the image locally. Anything that goes wrong should be caught in the PR-check with this one.

## Anything Else?
NA

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
