### PR TITLE
fix cacert check

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,6 +126,8 @@ func Get() *IngressConfig {
 			options.Set("KafkaPassword", *broker.Sasl.Password)
 			options.Set("SASLMechanism", *broker.Sasl.SaslMechanism)
 			options.Set("Protocol", *broker.Sasl.SecurityProtocol)
+		}
+		if broker.Cacert != nil {
 			caPath, err := cfg.KafkaCa(broker)
 			if err != nil {
 				panic("Kafka CA failed to write")


### PR DESCRIPTION
Its possible that the cacert won't exist so we should be okay with it.
If it does exist and fails to write, we definitely have a problem

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Check for CACert before assuming we have it.

## Why?
Managed kafka doesn't provide a cacert, so we blow up trying to start. Fedramp still needs it

## How?
Throw a check in the config for it

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
