### PR TITLE
pull topic proper name from clowder

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,7 @@ func Get() *IngressConfig {
 		// Kafka
 		options.SetDefault("KafkaBrokers", clowder.KafkaServers)
 		options.SetDefault("KafkaTrackerTopic", clowder.KafkaTopics["platform.payload-status"].Name)
+		options.SetDefault("KafkaAnnounceTopic", clowder.KafkaTopics["platform.upload.announce"].Name)
 		// Kafka SSL Config
 		if broker.Authtype != nil {
 			options.Set("KafkaUsername", *broker.Sasl.Username)


### PR DESCRIPTION
The kafka topic needs to pull its name from the clowder config

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Set the announce topic to pull name from clowder

## Why?
Clowder provides the proper naem for the topic based on the requested name. This change allows the actual topic to be updated if something changes.

## How?
Add clowder config for announce topic

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
