### PR TITLE
[fix] Ensure we grab the announce topic from clowder

### DIFF
--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -87,6 +87,7 @@ func (kv *Validator) Validate(vr *validators.Request) {
 	}
 	topic := serviceToTopic(vr.Service)
 	topic = fmt.Sprintf("platform.upload.%s", topic)
+	announceTopic := config.Get().KafkaConfig.KafkaAnnounceTopic
 	realizedTopicName := config.GetTopic(topic)
 	l.Log.WithFields(logrus.Fields{"data": data, "topic": realizedTopicName}).Debug("Posting data to topic")
 	message := validators.ValidationMessage{
@@ -97,10 +98,10 @@ func (kv *Validator) Validate(vr *validators.Request) {
 	}
 	switch account := vr.Account; account {
 	case "":
-		kv.ValidationProducerMapping[config.Get().KafkaConfig.KafkaAnnounceTopic] <- message
+		kv.ValidationProducerMapping[config.GetTopic(announceTopic)] <- message
 	default:
 		kv.ValidationProducerMapping[realizedTopicName] <- message
-		kv.ValidationProducerMapping[config.Get().KafkaConfig.KafkaAnnounceTopic] <- message
+		kv.ValidationProducerMapping[config.GetTopic(announceTopic)] <- message
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Grab the announce topic name from clowder

## Why?
We are not grabbing the announce topic from clowder like we're supposed to. This is a quick fix for that

## How?
Call GetTopic() 

## Testing
Testing in stage

## Anything Else?
We need to refactor this by passing the config around. This is not a great way to do it

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
