### PR TITLE
Only allow valid uuids for the /track/request_id endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/jarcoal/httpmock v1.0.8
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -91,7 +91,8 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "format": "uuid"
                         }
                     },
                     {
@@ -123,6 +124,9 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "Request_id is not in an UUID format"
                     },
                     "403": {
                         "description": "Authentication failure for specific request_id"

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -13,6 +13,7 @@ import (
 	l "github.com/redhatinsights/insights-ingress-go/internal/logger"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -55,6 +56,12 @@ func NewHandler(
 
 		if cfg.Auth {
 			id = identity.Get(r.Context())
+		}
+
+		if !isValidUUID(reqID) {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("request id is not an uuid"))
+			return
 		}
 
 		verbosity, _ := strconv.Atoi(r.URL.Query().Get("verbosity"))
@@ -124,4 +131,9 @@ func NewHandler(
 
 func isIdAuthorized(identity identity.Identity, accountNumber string, orgID string) bool {
 	return identity.AccountNumber == accountNumber || identity.OrgID == orgID
+}
+
+func isValidUUID(s string) bool {
+	_, err := uuid.Parse(s)
+	return err == nil
 }


### PR DESCRIPTION
## What?
Request Id validation for the track endpoint

Jira: https://issues.redhat.com/browse/RHCLOUD-19835

## Why?
Request ids are always in uuid format. It's good to enforce it for the track/request_id endpoint

## How?
Added an `isValidUUID()` function that checks whether or not the `request_id` is a valid UUID.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
