### PR TITLE
[task] Add a service lable to message produce count

### DIFF
--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -99,6 +99,7 @@ func (kv *Validator) Validate(vr *validators.Request) {
 	switch account := vr.Account; account {
 	case "":
 		kv.ValidationProducerMapping[config.GetTopic(announceTopic)] <- message
+		incMessageProduced(vr.Service)
 	default:
 		kv.ValidationProducerMapping[realizedTopicName] <- message
 		kv.ValidationProducerMapping[config.GetTopic(announceTopic)] <- message

--- a/internal/validators/kafka/metrics.go
+++ b/internal/validators/kafka/metrics.go
@@ -17,10 +17,19 @@ var (
 		Name: "ingress_validate_elapsed_seconds",
 		Help: "Number of seconds spent to validating",
 	}, []string{"outcome"})
+
+	messageProduced = pa.NewCounterVec(p.CounterOpts{
+		Name: "ingress_message_produced",
+		Help: "The total number of messages produced",
+	}, []string{"service"})
 )
 
 func inc(outcome string) {
 	payloadsProcessed.With(p.Labels{"outcome": outcome}).Inc()
+}
+
+func incMessageProduced(service string) {
+	messageProduced.With(p.Labels{"service": service}).Inc()
 }
 
 func observeValidationElapsed(timestamp time.Time, outcome string) {


### PR DESCRIPTION
Now that we're moving to a new single topic, we still need to know which
service is getting messages. We also want to be able to count the
messages per service.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Add a service label to the metrics for produced messages

## Why?
We're going to be switching everyone to a single topic, but we still need to know how many messages are going to each service. This will allow us to filter.

## How?
Added a new message count metric with a service label

## Testing
Tested in Ephemeral. It does what we want

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
