### PR TITLE
[feat] Add ability to add a kafka message key to a payload

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -42,7 +42,7 @@ type ProducerConfig struct {
 	Protocol             string
 	SASLMechanism        string
 	KafkaDeliveryReports bool
-	Debug				 bool
+	Debug                bool
 }
 
 // Producer consumes in and produces to the topic in config

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -105,6 +105,7 @@ func Producer(in chan validators.ValidationMessage, config *ProducerConfig) {
 					Partition: kafka.PartitionAny,
 				},
 				Value: v.Message,
+				Key:   v.Key,
 			}, delivery_chan)
 			messagePublishElapsed.With(prom.Labels{"topic": config.Topic}).Observe(time.Since(start).Seconds())
 

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -249,7 +249,6 @@ func NewHandler(
 			vr.Account = id.Identity.AccountNumber
 			vr.Principal = id.Identity.OrgID
 			vr.OrgID = id.Identity.OrgID
-			vr.ClusterID = id.Identity.System.ClusterId
 			requestLogger = requestLogger.WithFields(logrus.Fields{"account": vr.Account, "orgid": vr.OrgID})
 		}
 

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -249,6 +249,7 @@ func NewHandler(
 			vr.Account = id.Identity.AccountNumber
 			vr.Principal = id.Identity.OrgID
 			vr.OrgID = id.Identity.OrgID
+			vr.ClusterID = id.Identity.System.ClusterId
 			requestLogger = requestLogger.WithFields(logrus.Fields{"account": vr.Account, "orgid": vr.OrgID})
 		}
 

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -243,7 +243,7 @@ var _ = Describe("Upload", func() {
 					},
 					&FilePart{
 						Name:        "metadata",
-						Content:     `{"account": "012345", "custom_metadata": {"foo": "bar"}}`,
+            Content:     `{"account": "012345", "custom_metadata": {"foo": "bar"}, "queue_key": "12345"}`,
 						ContentType: "text/plain",
 					},
 				)
@@ -252,7 +252,7 @@ var _ = Describe("Upload", func() {
 				vin := validator.In
 				vin.Metadata.StaleTimestamp = timeNow
 				Expect(vin).To(Not(BeNil()))
-				Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress", CustomMetadata: map[string]string{"foo": "bar"}, StaleTimestamp: timeNow}))
+        Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress", CustomMetadata: map[string]string{"foo": "bar"}, QueueKey: "12345", StaleTimestamp: timeNow}))
 			})
 		})
 

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -243,7 +243,7 @@ var _ = Describe("Upload", func() {
 					},
 					&FilePart{
 						Name:        "metadata",
-            Content:     `{"account": "012345", "custom_metadata": {"foo": "bar"}, "queue_key": "12345"}`,
+            Content:     `{"account": "012345", "custom_metadata": {"foo": "bar"}}`,
 						ContentType: "text/plain",
 					},
 				)
@@ -252,9 +252,32 @@ var _ = Describe("Upload", func() {
 				vin := validator.In
 				vin.Metadata.StaleTimestamp = timeNow
 				Expect(vin).To(Not(BeNil()))
-        Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress", CustomMetadata: map[string]string{"foo": "bar"}, QueueKey: "12345", StaleTimestamp: timeNow}))
+        Expect(vin.Metadata).To(Equal(validators.Metadata{Account: "012345", Reporter: "ingress", CustomMetadata: map[string]string{"foo": "bar"}, StaleTimestamp: timeNow}))
 			})
 		})
+
+    Context("with a metadata part containing a queue key", func() {
+      It("should return HTTP 202", func() {
+        boiler(http.StatusAccepted,
+          &FilePart{
+            Name:        "file",
+            Content:     "testing",
+            ContentType: "application/vnd.redhat.unit.test",
+          },
+          &FilePart{
+            Name:        "metadata",
+            Content:     `{"queue_key": "12345"}`,
+            ContentType: "text/plain",
+          },
+        )
+        in := stager.Input
+        Expect(in).To(Not(BeNil()))
+        vin := validator.In
+        vin.Metadata.StaleTimestamp = timeNow
+        Expect(vin).To(Not(BeNil()))
+        Expect(vin.Metadata).To(Equal(validators.Metadata{Reporter: "ingress", QueueKey: "12345", StaleTimestamp: timeNow}))
+      })
+    })
 
 		Context("with an invalid metadata part", func() {
 			It("will still return HTTP 202", func() {

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -42,7 +42,7 @@ type Config struct {
 	CA              string
 	Protocol        string
 	SASLMechanism   string
-	Debug		    bool
+	Debug           bool
 }
 
 // New constructs and initializes a new Kafka Validator

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -96,8 +96,8 @@ func (kv *Validator) Validate(vr *validators.Request) {
 			"service": vr.Service,
 		},
 	}
-	if vr.ClusterID != "" {
-		message.Key = []byte(vr.ClusterID)
+	if vr.Metadata.QueueKey != "" {
+		message.Key = []byte(vr.Metadata.QueueKey)
 	}
 	switch account := vr.Account; account {
 	case "":

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -96,6 +96,9 @@ func (kv *Validator) Validate(vr *validators.Request) {
 			"service": vr.Service,
 		},
 	}
+	if vr.ClusterID != "" {
+		message.Key = []byte(vr.ClusterID)
+	}
 	switch account := vr.Account; account {
 	case "":
 		kv.ValidationProducerMapping[config.GetTopic(announceTopic)] <- message

--- a/internal/validators/types.go
+++ b/internal/validators/types.go
@@ -19,7 +19,7 @@ type Request struct {
 	ID          string    `json:"id,omitempty"`
 	B64Identity string    `json:"b64_identity"`
 	Timestamp   time.Time `json:"timestamp"`
-	ClusterID   string	  `json:"cluster_id"`
+	ClusterID   string    `json:"cluster_id"`
 }
 
 // Metadata is the expected data from a client
@@ -43,7 +43,7 @@ type Metadata struct {
 type ValidationMessage struct {
 	Message []byte
 	Headers map[string]string
-	Key	    []byte 
+	Key     []byte
 }
 
 // ServiceDescriptor is used to select a message topic

--- a/internal/validators/types.go
+++ b/internal/validators/types.go
@@ -37,7 +37,7 @@ type Metadata struct {
 	CustomMetadata map[string]string `json:"custom_metadata,omitempty"`
 	Reporter       string            `json:"reporter"`
 	StaleTimestamp time.Time         `json:"stale_timestamp"`
-	QueueKey	   string            `json:"queue_key,omitempty"`
+	QueueKey       string            `json:"queue_key,omitempty"`
 }
 
 type ValidationMessage struct {

--- a/internal/validators/types.go
+++ b/internal/validators/types.go
@@ -19,7 +19,6 @@ type Request struct {
 	ID          string    `json:"id,omitempty"`
 	B64Identity string    `json:"b64_identity"`
 	Timestamp   time.Time `json:"timestamp"`
-	ClusterID   string    `json:"cluster_id"`
 }
 
 // Metadata is the expected data from a client
@@ -38,6 +37,7 @@ type Metadata struct {
 	CustomMetadata map[string]string `json:"custom_metadata,omitempty"`
 	Reporter       string            `json:"reporter"`
 	StaleTimestamp time.Time         `json:"stale_timestamp"`
+	QueueKey	   string            `json:"queue_key,omitempty"`
 }
 
 type ValidationMessage struct {

--- a/internal/validators/types.go
+++ b/internal/validators/types.go
@@ -19,6 +19,7 @@ type Request struct {
 	ID          string    `json:"id,omitempty"`
 	B64Identity string    `json:"b64_identity"`
 	Timestamp   time.Time `json:"timestamp"`
+	ClusterID   string	  `json:"cluster_id"`
 }
 
 // Metadata is the expected data from a client
@@ -42,6 +43,7 @@ type Metadata struct {
 type ValidationMessage struct {
 	Message []byte
 	Headers map[string]string
+	Key	    []byte 
 }
 
 // ServiceDescriptor is used to select a message topic


### PR DESCRIPTION
The key will help upstream consumers keep messages in order

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?

Allow uploading clients to use a Metadata field in order to attach a key to an upload. This key will be used to keep messages from a particular client in order.

RHCLOUD-20004

## Why?

Keys in kafka messages make it possible to keep track of the order things are recieved
and ensure the messages with the same key show up on the same partition

## How?

Create a metadata field for queue_key that lets a client set the key for an upload. 

## Testing

In progress

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
