### PR TITLE
Enable TLS without SASL auth for kafka

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -52,25 +52,24 @@ func Producer(in chan validators.ValidationMessage, config *ProducerConfig) {
 
 	var configMap kafka.ConfigMap
 
-	if config.SASLMechanism != "" {
-		configMap = kafka.ConfigMap{
-			"bootstrap.servers":   config.Brokers[0],
-			"security.protocol":   config.Protocol,
-			"sasl.mechanism":      config.SASLMechanism,
-			"ssl.ca.location":     config.CA,
-			"sasl.username":       config.Username,
-			"sasl.password":       config.Password,
-			"go.delivery.reports": config.KafkaDeliveryReports,
-		}
-	} else {
-		configMap = kafka.ConfigMap{
-			"bootstrap.servers":   config.Brokers[0],
-			"go.delivery.reports": config.KafkaDeliveryReports,
+	configMap = kafka.ConfigMap{
+		"bootstrap.servers": config.Brokers[0],
+		"go.delivery.reports": config.KafkaDeliveryReports,
+	}
+
+	if config.CA != "" {
+		_ = configMap.SetKey("security.protocol", config.Protocol)
+		_ = configMap.SetKey("ssl.ca.location", config.CA)
+
+		if config.SASLMechanism != "" {
+			_ = configMap.SetKey("sasl.mechanism", config.SASLMechanism)
+			_ = configMap.SetKey("sasl.username", config.Username)
+			_ = configMap.SetKey("sasl.password", config.Password)
 		}
 	}
 
 	if config.Debug {
-		configMap.SetKey("debug", "protocol,broker,topic")
+		_ = configMap.SetKey("debug", "protocol,broker,topic")
 	}
 
 	p, err := kafka.NewProducer(&configMap)


### PR DESCRIPTION
We had tied kafka's encryption to the authentication mechanisms. In future environments, we may need to be able to do TLS without having to use SASL.

Also took the opprotunity to stop repeating ourselves within the kafka configs

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## What?
Separate the kafka CA cert config from the SASL config. 

## Why?
We will need to use TLS without assuming authentication mechanisms in the future. This decouples those from each other.

## How?
If we have a kafka CA, we'll add that to our kafka config. If we have that, we then check for SASL mechanism to see if we have those values. If we do, we'll add it. otherwise we leave those unconfigured.

## Testing
Did you add any tests for the change?

## Anything Else?
Used `SetKey` so we could do less repeating of ourselves. SetKey is weird in that it can return an error, but we don't care about that so we just make sure we handle it, but we don't store it.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
