### PR TITLE
[feat] Add a deny list ability to IngressConfig

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type IngressConfig struct {
 	PayloadTrackerURL    string
 	StorageConfig        StorageCfg
 	LoggingConfig        LoggingCfg
+	DenyList             []string
 	Debug                bool
 	DebugUserAgent       *regexp.Regexp
 }
@@ -102,6 +103,7 @@ func Get() *IngressConfig {
 	options.SetDefault("OpenshiftBuildCommit", "notrunninginopenshift")
 	options.SetDefault("ValidTopics", "unit,announce")
 	options.SetDefault("Profile", false)
+	options.SetDefault("DenyList", []string{})
 	options.SetDefault("Debug", false)
 	options.SetDefault("DebugUserAgent", `unspecified`)
 	options.SetEnvPrefix("INGRESS")
@@ -182,6 +184,7 @@ func Get() *IngressConfig {
 		Version:              os.Getenv("1.0.8"),
 		PayloadTrackerURL:    options.GetString("PayloadTrackerURL"),
 		Profile:              options.GetBool("Profile"),
+		DenyList:             strings.Split(",", options.GetString("DenyList")),
 		Debug:                options.GetBool("Debug"),
 		DebugUserAgent:       regexp.MustCompile(options.GetString("DebugUserAgent")),
 		KafkaConfig: KafkaCfg{

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -175,6 +175,13 @@ func NewHandler(
 			id.Identity.OrgID = id.Identity.Internal.OrgID
 		}
 
+		for _, orgID := range cfg.DenyList {
+			if orgID == id.Identity.OrgID {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte("Upload denied. Please contact Red Hat Support."))
+			}
+		}
+
 		incRequests(userAgent)
 		file, fileHeader, err := GetFile(r, cfg.MaxUploadMem)
 		if err != nil {

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -436,6 +436,19 @@ var _ = Describe("Upload", func() {
 				})
 			})
 		})
+		Context("with a denied orgID", func() {
+			It("should return 403", func() {
+				DenyList := []string{"12345"}
+				cfg := config.Get()
+				cfg.DenyList = DenyList
+				handler = NewHandler(stager, validator, tracker, *cfg)
+				boiler(http.StatusUnauthorized, &FilePart{
+					Name: "file",
+					Content: "testing",
+					ContentType: "application/vnd.redhat.unit.test",
+				})
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
We need to be able to block accounts when there are problematic archives being pushed to the platform. Ingress is a reasonable place to make this happen easily due to having the OrgID available from the identity header.

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## What?
Add a denylist var to ingress so that we can add "bad" orgIDs if we need to

## Why?
We have encountered at least one instance where an account/orgID was sending in archives that were causing major platform issues. When it's not simple to stop the archives from coming in, or check for the data itself, we should be able to stop the account from uploading until we can contact the customer.

## How?
Add a denyList environment variable to ingress that can have orgIDs listed that we do nto want to allow through.

## Testing
Tests included

## Anything Else?


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
