### PR TITLE
feat: Add configurable storage region

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type StorageCfg struct {
 	StorageAccessKey string
 	StorageSecretKey string
 	UseSSL           bool
+	StorageRegion    string
 }
 
 type LoggingCfg struct {
@@ -154,6 +155,11 @@ func Get() *IngressConfig {
 		options.SetDefault("MinioAccessKey", cfg.ObjectStore.Buckets[0].AccessKey)
 		options.SetDefault("MinioSecretKey", cfg.ObjectStore.Buckets[0].SecretKey)
 		options.SetDefault("UseSSL", cfg.ObjectStore.Tls)
+		if cfg.ObjectStore.Buckets[0].Region != nil {
+			options.SetDefault("StorageRegion", cfg.ObjectStore.Buckets[0].Region)
+		} else {
+			options.SetDefault("StorageRegion", "")
+		}
 		// Cloudwatch
 		options.SetDefault("logGroup", cfg.Logging.Cloudwatch.LogGroup)
 		options.SetDefault("AwsRegion", cfg.Logging.Cloudwatch.Region)
@@ -172,6 +178,7 @@ func Get() *IngressConfig {
 		options.SetDefault("MetricsPort", 8080)
 		// Storage
 		options.SetDefault("StageBucket", "available")
+		options.SetDefault("StorageRegion", "")
 		// Cloudwatch
 		options.SetDefault("LogGroup", "platform-dev")
 		options.SetDefault("AwsRegion", "us-east-1")
@@ -210,6 +217,7 @@ func Get() *IngressConfig {
 			StorageAccessKey: options.GetString("MinioAccessKey"),
 			StorageSecretKey: options.GetString("MinioSecretKey"),
 			UseSSL:           options.GetBool("UseSSL"),
+			StorageRegion:    options.GetString("StorageRegion"),
 		},
 		LoggingConfig: LoggingCfg{
 			LogGroup:           options.GetString("logGroup"),

--- a/internal/stage/s3compat/s3compat.go
+++ b/internal/stage/s3compat/s3compat.go
@@ -18,16 +18,21 @@ type Stager struct {
 // GetClient gets the s3 compatible client info
 func GetClient(cfg *config.IngressConfig, stager *Stager) stage.Stager {
 	var endpoint string
-	if cfg.StorageConfig.StorageEndpoint == "" {
+	storageCfg := cfg.StorageConfig
+	if storageCfg.StorageEndpoint == "" {
 		endpoint = "s3.amazonaws.com"
 	} else {
-		endpoint = cfg.StorageConfig.StorageEndpoint
+		endpoint = storageCfg.StorageEndpoint
 	}
-	accessKeyID := cfg.StorageConfig.StorageAccessKey
-	secretAccessKey := cfg.StorageConfig.StorageSecretKey
-	useSSL := cfg.StorageConfig.UseSSL
+	accessKeyID := storageCfg.StorageAccessKey
+	secretAccessKey := storageCfg.StorageSecretKey
+	useSSL := storageCfg.UseSSL
 
-	stager.Client, _ = minio.New(endpoint, accessKeyID, secretAccessKey, useSSL)
+	if storageCfg.StorageRegion != "" { 
+		stager.Client, _ = minio.NewWithRegion(endpoint, accessKeyID, secretAccessKey, useSSL, storageCfg.StorageRegion)
+	} else {
+		stager.Client, _ = minio.New(endpoint, accessKeyID, secretAccessKey, useSSL)
+	}
 
 	return stager
 }


### PR DESCRIPTION
Minio assumes a region if we do not provide one and this can occasionally be incorrect. By providing a region we also make bucket lookups faster.

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## What?
Add a configurable storage region

## Why?
We don't always want our region to be us-east-1, so we need a way to configure the region. Minio does attempt to look things up, but we have seen errors where it picks the wrong region entirely.

## How?
Add an option to pull the region from clowder if its available, or set it if we need to. Otherwise it will default to an empty string.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
