### PR TITLE
[fix] Pull bucket.Name from clowder for bucket name

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,7 +150,7 @@ func Get() *IngressConfig {
 		options.SetDefault("WebPort", cfg.PublicPort)
 		options.SetDefault("MetricsPort", cfg.MetricsPort)
 		// Storage
-		options.SetDefault("StageBucket", bucket.RequestedName)
+		options.SetDefault("StageBucket", bucket.Name)
 		options.SetDefault("MinioEndpoint", fmt.Sprintf("%s:%d", cfg.ObjectStore.Hostname, cfg.ObjectStore.Port))
 		options.SetDefault("MinioAccessKey", cfg.ObjectStore.Buckets[0].AccessKey)
 		options.SetDefault("MinioSecretKey", cfg.ObjectStore.Buckets[0].SecretKey)


### PR DESCRIPTION
We should be pulling the name of the bucket itself rather than the
requested name

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## What?
Explain what the change is linking any relevant JIRAs or Issues.

use bucket.Name from clowder rather than bucket.RequestName as the name of the actual bucket.
I checked all environments to ensure this would not cause a disruption. The names are the same in *most* envrionments

## Why?
Consider what business or engineering goal does this PR achieves.

One of our environments is busted because the requestedName and the Name are different. The Name is the actual name of the bucket

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

Changed a default variable in the config

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
