### PR TITLE
refactor: simplify the https connection logic

### DIFF
--- a/cmd/insights-ingress/main.go
+++ b/cmd/insights-ingress/main.go
@@ -2,10 +2,7 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -42,36 +39,6 @@ func apiSpec(w http.ResponseWriter, r *http.Request) {
 	w.Write(api.ApiSpec)
 }
 
-func configureHttpClient(cfg config.IngressConfig) *http.Client {
-	if cfg.TlsCAPath != "" {
-		rootCAs, _ := x509.SystemCertPool()
-		if rootCAs == nil {
-			rootCAs = x509.NewCertPool()
-		}
-
-		certs, err := ioutil.ReadFile(cfg.TlsCAPath)
-		if err != nil {
-			l.Log.Error("Failed to append CA to RootCAs")
-		}
-
-		if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-			l.Log.Info("No certs appended, using system certs only")
-		}
-
-		httpConfig := &tls.Config{
-			InsecureSkipVerify: false,
-			RootCAs:            rootCAs,
-		}
-		httpTransport := &http.Transport{TLSClientConfig: httpConfig}
-		client := &http.Client{Transport: httpTransport,
-			Timeout: time.Second * cfg.HTTPClientTimeout,
-		}
-
-		return client
-	} else {
-		return &http.Client{Timeout: time.Second * cfg.HTTPClientTimeout}
-	}
-}
 
 func main() {
 	cfg := config.Get()
@@ -123,7 +90,9 @@ func main() {
 		stager, validator, tracker, *cfg,
 	)
 
-	httpClient := configureHttpClient(*cfg)
+	httpClient := &http.Client{
+		Timeout: time.Second * time.Duration(cfg.HTTPClientTimeout),
+	}
 
 	trackEndpoint := track.NewHandler(
 		*cfg,

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -64,6 +64,8 @@ objects:
           value: ${INGRESS_MINIOENDPOINT}
         - name: INGRESS_BLACK_LISTED_ORGIDS
           value: ${INGRESS_BLACK_LISTED_ORGIDS}
+        - name: SSL_CERT_DIR
+          value: ${SSL_CERT_DIR}
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -176,3 +178,5 @@ parameters:
   required: true
 - name: INGRESS_BLACK_LISTED_ORGIDS
   value: ""
+- name: SSL_CERT_DIR
+  value: '/etc/ssl/certs:/etc/pki/tls/certs:/system/etc/security/cacerts:/cdapp/certs'


### PR DESCRIPTION
Use the SSL_CERT_DIR environment variable to provide a path to the SSL CA cert

## What?
Add the /cdapp/certs directory for reading CA certs

## Why?
this allows pods to communicate in the platform over TLS encrypted connections

## How?
golang will automatically look in the directories listed in this environment variable for ca certs

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
