### PR TITLE
Try to centralize the knowledge of how to setup ingress locally and run a quick test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,36 @@
-build:
+include development/.env
 
-	go build -o insights-ingress-go cmd/insights-ingress/main.go
+BINARY=insights-ingress-go
+
+.PHONY: $(BINARY)
+
+build: $(BINARY)
+
+$(BINARY):
+	go build -o $(BINARY) cmd/insights-ingress/main.go
 
 test:
-
 	go test -p 1 -v ./...
+
+run-api: $(BINARY)
+	INGRESS_STAGEBUCKET=insights-upload-perma \
+	INGRESS_VALIDTOPICS=advisor,qpc \
+	OPENSHIFT_BUILD_COMMIT=somestring \
+	INGRESS_MINIODEV=true \
+	INGRESS_MINIOACCESSKEY=$(MINIO_ACCESS_KEY) \
+	INGRESS_MINIOSECRETKEY=$(MINIO_SECRET_KEY) \
+	INGRESS_KAFKA_BROKERS=localhost:29092 \
+	INGRESS_MINIOENDPOINT=localhost:9000 \
+	./$(BINARY)
+
+run-upload-test:
+	curl -v -F "file=@go.mod;type=application/vnd.redhat.advisor.tgz" \
+	-H "x-rh-identity: eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMiIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9LCAidHlwZSI6ICJiYXNpYyJ9fQ==" \
+	-H "x-rh-request-id: 1234" \
+	http://localhost:3000/api/ingress/v1/upload
+
+start-api-dependencies:
+	cd development/ && sh .env && podman-compose -f local-dev-start.yml up zookeeper kafka minio minio-createbucket
+
+stop-api-dependencies:
+	podman-compose -f development/local-dev-start.yml down

--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ cloud.redhat.com, the customer should engage with support.
 
 #### Prerequisites
 
-Golang >= 1.12
+Golang >= 1.16
 
 #### Launching the Service
 
 Compile the source code into a go binary:
 
-    $> go build
+    $> make build
 
 Launch the application
 
@@ -150,9 +150,9 @@ You can also build ingress using Docker/Podman with the provided Dockerfile.
 
     $> docker build . -t ingress:latest
 
-### Podman Compose
+### Local Development
 
-See [instructions](https://github.com/RedHatInsights/insights-ingress-go/blob/master/development/README.md)
+More information on local development can be found [here](./development/README.md)
 
 #### Uploading a File
 
@@ -176,4 +176,4 @@ This decodes to:
 
 Use `go test` to test the application
 
-    $> go test ./...
+    $> make test

--- a/development/README.md
+++ b/development/README.md
@@ -5,7 +5,7 @@ The podman compose file found in this directory will standup kafka and minio for
 ## Requirements
 * podman
 * podman-compose
-* golang => 1.12
+* golang => 1.16
 
 Docker will alos work if that is all you have
 
@@ -15,40 +15,30 @@ In order to run the local development stack, execute the following command. Subs
 
     $> podman-compose -f local-dev-start.yml up
 
-Once the local environment is running, you must setup the buckets in Minio so that ingress has something to write to.
+This should build the ingress image, start the dependencies (kafka, minio, etc) and start the ingress
+service within podman.
 
-1. Login to localhost:9000 using the creds found in `.env`
-   + Note: accessing localhost:9000 will forward you to minio console which runs on a dynamic port. Access the api by referencing the ip of minio directly, shown on app startup. Example: 
-     + > podman start -a development_minio_1 <br> API: http://10.89.0.12:9000  http://127.0.0.1:9000
-     + for more info see: [Minio Static vs Dynamic Port Assignment](https://docs.min.io/minio/baremetal/console/minio-console.html#static-vs-dynamic-port-assignment)
-   + username = `MINIO_ACCESS_KEY`, password = `MINIO_SECRET_KEY`
-2. Click the `Create Bucket +` sign in the top right corner
-3. Create a bucket called `insights-upload-perma`
-4. Once created, hover over the name in the left navigation menu and click the 3 dots.
-5. Click "edit policy"
-6. Change the dropdown box to "Read and Write"
+Once the local environment is running, you can load `http://localhost:9990/` to access the minio console.
+The required buckets should be created automatically by podman.
 
 ## Building and Running Ingress from Source
 
-Ensure you are in the following directory: [/cmd/insights-ingress](../cmd/insights-ingress/.), and execute the following commands:
+It is also possible to run the ingress service locally but configure it so that the service uses the
+dependencies that are running within podman.
 
-    $> go get ./...
-    $> go build
+The `make start-api-dependencies` Makefile rule can be used to start the dependencies using podman-compose:
 
-Alternatively, you can leverage [Makefile](../Makefile) from the root of the repo and run:
+    $> make start-api-dependencies
 
-    $> make build
+The `make run-api` Makefile rule can be used to run ingress locally:
 
-There should now be an executable in the directory. You need to supply some env vars for the application to work
-properly. Here is an example:
-
-    $> INGRESS_STAGEBUCKET=insights-upload-perma INGRESS_VALIDTOPICS=advisor OPENSHIFT_BUILD_COMMIT=somestring INGRESS_MINIODEV=true INGRESS_MINIOACCESSKEY=$MINIO_ACCESS_KEY INGRESS_MINIOSECRETKEY=$MINIO_SECRET_KEY INGRESS_KAFKA_BROKERS=localhost:9092 INGRESS_MINIOENDPOINT=localhost:9000 ./insights-ingress
-
-## Running from Podman
-
-In order to run as part of the dev environment, you can also uncomment the ingress stanza in `local-dev-start.yml`. This will attempt to pull the ingress image from Quay. You must first login to the Quay registry at quay.io and have access to the Cloudservices namespace. If you do not have this, please put in an RHIOPS ticket to gain access.
+    $> make run-api
 
 ## Uploading
+
+The `make run-upload-test` Makefile rule can be used to run send an upload to the ingress service locally:
+
+    $> make run-upload-test
 
 To test an upload, you can use an insights-archive, or any other type of file that is accepted by the end services of cloud.redhat.com
 

--- a/development/local-dev-start.yml
+++ b/development/local-dev-start.yml
@@ -22,15 +22,29 @@ services:
       - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
   minio:
     image: minio/minio
-    command: server /data
+    command: server --address 0.0.0.0:9000 --console-address 0.0.0.0:9990 /data
     volumes:
-      - '/mnt/config:/data:z'
-      - '/mnt/data:/root/.minio:z'
+      - './minio-conf:/mnt/config:z'
+      - './minio-data/.minio:/mnt/data:z'
     ports:
       - 9000:9000
+      - 9990:9990
     environment:
-      - MINIO_ACCESS_KEY=$MINIO_ACCESS_KEY
-      - MINIO_SECRET_KEY=$MINIO_SECRET_KEY
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+      - MINIO_ROOT_USER=${MINIO_ACCESS_KEY}
+      - MINIO_ROOT_PASSWORD=${MINIO_SECRET_KEY}
+  minio-createbucket:
+    image: minio/mc
+    depends_on:
+      - minio
+    restart: on-failure
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host add myminio http://minio:9000 ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} || exit 1;
+      /usr/bin/mc mb --ignore-existing myminio/insights-upload-perma;
+      /usr/bin/mc policy set public myminio/insights-upload-perma;
+      "
   ingress:
     #image: quay.io/cloudservices/insights-ingress:latest
     image: ingress:latest
@@ -49,4 +63,5 @@ services:
       - INGRESS_MINIOSECRETKEY=$MINIO_SECRET_KEY
       - INGRESS_MINIOENDPOINT=minio:9000
     depends_on:
-       - kafka
+      - kafka
+      - minio


### PR DESCRIPTION
To start kafka, minio:  `make start-api-dependencies`
To run ingress:  `make run-api`
To run test upload: `make run-upload-test`
Top stop kafka, minio:  `make stop-api-dependencies`