### PR TITLE
Revert "Fix spelling of announce topic config name"

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,7 +96,7 @@ func Get() *IngressConfig {
 	options.SetDefault("KafkaGroupID", "ingress")
 	options.SetDefault("KafkaDeliveryReports", true)
 	options.SetDefault("KafkaTrackerTopic", "platform.payload-status")
-	options.SetDefault("KafkaAnnounceTopic", "platform.upload.announce")
+	options.SetDefault("KafakAnnounceTopic", "platform.upload.announce")
 	options.SetDefault("KafkaSecurityProtocol", "PLAINTEXT")
 
 	// Global defaults
@@ -216,7 +216,7 @@ func Get() *IngressConfig {
 			KafkaGroupID:          options.GetString("KafkaGroupID"),
 			KafkaTrackerTopic:     options.GetString("KafkaTrackerTopic"),
 			KafkaDeliveryReports:  options.GetBool("KafkaDeliveryReports"),
-			KafkaAnnounceTopic:    options.GetString("KafkaAnnounceTopic"),
+			KafkaAnnounceTopic:    options.GetString("KafakAnnounceTopic"),
 			ValidTopics:           strings.Split(options.GetString("ValidTopics"), ","),
 			KafkaSecurityProtocol: options.GetString("KafkaSecurityProtocol"),
 		},


### PR DESCRIPTION
This reverts commit c1395a5a710fa60a90cfd67f78aac56d0609b00d.