### PR TITLE
Fix spelling of announce topic config name

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,7 +96,7 @@ func Get() *IngressConfig {
 	options.SetDefault("KafkaGroupID", "ingress")
 	options.SetDefault("KafkaDeliveryReports", true)
 	options.SetDefault("KafkaTrackerTopic", "platform.payload-status")
-	options.SetDefault("KafakAnnounceTopic", "platform.upload.announce")
+	options.SetDefault("KafkaAnnounceTopic", "platform.upload.announce")
 	options.SetDefault("KafkaSecurityProtocol", "PLAINTEXT")
 
 	// Global defaults
@@ -216,7 +216,7 @@ func Get() *IngressConfig {
 			KafkaGroupID:          options.GetString("KafkaGroupID"),
 			KafkaTrackerTopic:     options.GetString("KafkaTrackerTopic"),
 			KafkaDeliveryReports:  options.GetBool("KafkaDeliveryReports"),
-			KafkaAnnounceTopic:    options.GetString("KafakAnnounceTopic"),
+			KafkaAnnounceTopic:    options.GetString("KafkaAnnounceTopic"),
 			ValidTopics:           strings.Split(options.GetString("ValidTopics"), ","),
 			KafkaSecurityProtocol: options.GetString("KafkaSecurityProtocol"),
 		},

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -101,11 +101,11 @@ func (kv *Validator) Validate(vr *validators.Request) {
 	}
 	switch account := vr.Account; account {
 	case "":
-		kv.ValidationProducerMapping[config.GetTopic(announceTopic)] <- message
+		kv.ValidationProducerMapping[announceTopic] <- message
 		incMessageProduced(vr.Service)
 	default:
 		kv.ValidationProducerMapping[realizedTopicName] <- message
-		kv.ValidationProducerMapping[config.GetTopic(announceTopic)] <- message
+		kv.ValidationProducerMapping[announceTopic] <- message
 	}
 }
 

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -96,12 +96,6 @@ func (kv *Validator) Validate(vr *validators.Request) {
 			"service": vr.Service,
 		},
 	}
-
-    fmt.Println("announcetopic: |", announceTopic, "|")
-    fmt.Println("config.GetTopic(announceTopic)]: |", config.GetTopic(announceTopic), "|")
-    fmt.Println("realizedTopicName: |", realizedTopicName, "|")
-
-
 	if vr.Metadata.QueueKey != "" {
 		message.Key = []byte(vr.Metadata.QueueKey)
 	}

--- a/internal/validators/kafka/kafka.go
+++ b/internal/validators/kafka/kafka.go
@@ -96,6 +96,12 @@ func (kv *Validator) Validate(vr *validators.Request) {
 			"service": vr.Service,
 		},
 	}
+
+    fmt.Println("announcetopic: |", announceTopic, "|")
+    fmt.Println("config.GetTopic(announceTopic)]: |", config.GetTopic(announceTopic), "|")
+    fmt.Println("realizedTopicName: |", realizedTopicName, "|")
+
+
 	if vr.Metadata.QueueKey != "" {
 		message.Key = []byte(vr.Metadata.QueueKey)
 	}


### PR DESCRIPTION
## What?
Fix spelling of announce topic config name
Do not map the announce topic name in the validator module.  This happens already in the config code.
