### PR TITLE
switch to using denylist for blocking orgIDs

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -62,8 +62,8 @@ objects:
           value: ${CLOWDER_ENABLED}
         - name: INGRESS_MINIOENDPOINT
           value: ${INGRESS_MINIOENDPOINT}
-        - name: INGRESS_BLACK_LISTED_ORGIDS
-          value: ${INGRESS_BLACK_LISTED_ORGIDS}
+        - name: INGRESS_DENY_LISTED_ORGIDS
+          value: ${INGRESS_DENY_LISTED_ORGIDS}
         - name: SSL_CERT_DIR
           value: ${SSL_CERT_DIR}
         resources:
@@ -131,7 +131,7 @@ parameters:
   name: ENV_NAME
   value: "insights-ingress"
   required: true
-- name: INGRESS_BLACK_LISTED_ORGIDS
+- name: INGRESS_DENY_LISTED_ORGIDS
   value: ""
 - name: SSL_CERT_DIR
   value: '/etc/ssl/certs:/etc/pki/tls/certs:/system/etc/security/cacerts:/cdapp/certs'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ type IngressConfig struct {
 	TlsCAPath            string
 	StorageConfig        StorageCfg
 	LoggingConfig        LoggingCfg
-	BlackListedOrgIDs    []string
+	DenyListedOrgIDs    []string
 	Debug                bool
 	DebugUserAgent       *regexp.Regexp
 }
@@ -110,7 +110,7 @@ func Get() *IngressConfig {
 	options.SetDefault("OpenshiftBuildCommit", "notrunninginopenshift")
 	options.SetDefault("Valid_Upload_Types", "unit,announce")
 	options.SetDefault("Profile", false)
-	options.SetDefault("Black_Listed_OrgIDs", []string{})
+	options.SetDefault("Deny_Listed_OrgIDs", []string{})
 	options.SetDefault("Debug", false)
 	options.SetDefault("DebugUserAgent", `unspecified`)
 	options.SetEnvPrefix("INGRESS")
@@ -208,7 +208,7 @@ func Get() *IngressConfig {
 		PayloadTrackerURL:    options.GetString("PayloadTrackerURL"),
 		TlsCAPath:            options.GetString("TlsCAPath"),
 		Profile:              options.GetBool("Profile"),
-		BlackListedOrgIDs:    options.GetStringSlice("Black_Listed_OrgIDs"),
+		DenyListedOrgIDs:    options.GetStringSlice("Deny_Listed_OrgIDs"),
 		Debug:                options.GetBool("Debug"),
 		DebugUserAgent:       regexp.MustCompile(options.GetString("DebugUserAgent")),
 		KafkaConfig: KafkaCfg{

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -439,7 +439,7 @@ var _ = Describe("Upload", func() {
 		Context("with a denied orgID", func() {
 			It("should return 403", func() {
 				cfg := config.Get()
-				cfg.BlackListedOrgIDs = []string{"12345"}
+				cfg.DenyListedOrgIDs = []string{"12345"}
 				handler = NewHandler(stager, validator, tracker, *cfg)
 				boiler(http.StatusForbidden, &FilePart{
 					Name:        "file",


### PR DESCRIPTION
Just cleaning up the language we use in the app

## What?
Use Denylist instead of Blacklist throughout the code

## Why?
Use unbiased terms. Saw this somewhere in a RH presentation a while back and noticed what was done here while looking for something else. Took the opportunity to fix it.

## How?
Rename all occurences of blacklist to denylist

## Testing
The test file was updated and go test was run

## Anything Else?
We could choose to use "blocklist" instead of the team would rather do that.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
