### PR TITLE
update missing env variable

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -58,6 +58,8 @@ objects:
           value: ${INGRESS_VALID_UPLOAD_TYPES}
         - name: INGRESS_MAXSIZEMAP
           value: ${INGRESS_MAXSIZEMAP}
+        - name: INGRESS_DEFAULTMAXSIZE
+          value: ${INGRESS_DEFAULTMAXSIZE}
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
         - name: INGRESS_MINIOENDPOINT


### PR DESCRIPTION
## What?
While performing [load test](https://issues.redhat.com/browse/HCEPERF-38) on ingress/upload service, we noticed default configuration for upload service has max upload size set to 104 MB(this in context with service deployed in perf cluster). 
For more details on the issue [link](https://issues.redhat.com/browse/HCEPERF-39). Currently I have a workaround to proceed with the test but need this fix for future test automation work. 

## Why?
This will make it easier for us to run performance tests.

## How?
Parameter `INGRESS_DEFAULTMAXSIZE` should be mapped in env variables in `deploy/clowdapp.yaml` file.
