### PR TITLE
Fix track endpoint to work with service accounts which do not include the account number field

### DIFF
--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -2,7 +2,6 @@ package track
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -97,10 +96,9 @@ func NewHandler(
 			subjectSplit := strings.Split(id.Identity.X509.SubjectDN, "=")
 			subjectDN = subjectSplit[len(subjectSplit)-1]
 		}
-		fmt.Print(id.Identity.Type)
-		fmt.Print(subjectDN)
+
 		if id.Identity.Type != "Associate" && subjectDN != "insightspipelineqe" {
-			if !isIdAuthorized(id.Identity, pt.Data[0].Account, pt.Data[0].OrgID) {
+			if !isIdAuthorized(id.Identity, pt.Data[0].OrgID) {
 
 				incomingRequestID := request_id.GetReqID(r.Context())
 
@@ -144,8 +142,8 @@ func NewHandler(
 	}
 }
 
-func isIdAuthorized(identity identity.Identity, accountNumber string, orgID string) bool {
-	return identity.AccountNumber == accountNumber || identity.OrgID == orgID
+func isIdAuthorized(identity identity.Identity, orgID string) bool {
+	return identity.OrgID == orgID
 }
 
 func isValidUUID(s string) bool {

--- a/internal/track/track_test.go
+++ b/internal/track/track_test.go
@@ -50,6 +50,16 @@ func makeTestRequest(uri string, request_id string, account string, orgID string
 				},
 			},
 		})
+	case "serviceaccount":
+		ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
+			Identity: identity.Identity{
+				OrgID: orgID,
+				Internal: identity.Internal{
+					OrgID: orgID,
+				},
+				Type: "ServiceAccount",
+			},
+		})
 	default:
 		ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
 			Identity: identity.Identity{
@@ -121,16 +131,6 @@ var _ = Describe("Track", func() {
 			})
 		})
 
-		Context("with an incorrect orgID but valid account", func() {
-			It("should return an HTTP 200", func() {
-				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
-				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089719", "12346", "customer")
-				Expect(err).To(BeNil())
-				handler.ServeHTTP(rr, req)
-				Expect(rr.Code).To(Equal(200))
-			})
-		})
-
 		Context("with an invalid request-id", func() {
 			It("should return HTTP 404", func() {
 				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/3e3f56e642a248008811cce123b2c0f2", httpmock.NewStringResponder(200, badJsonID))
@@ -174,5 +174,28 @@ var _ = Describe("Track", func() {
 				Expect(rr.Body.String()).To(Equal(minimalJsonBody))
 			})
 		})
+
+		Context("with an service-account", func() {
+			It("should return HTTP 200", func() {
+				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "12345", "serviceaccount")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(200))
+				Expect(rr.Body).ToNot(BeNil())
+				Expect(rr.Body.String()).To(Equal(minimalJsonBody))
+			})
+		})
+
+		Context("with an service-account with an incorrect orgID", func() {
+			It("should return HTTP 403", func() {
+				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "12346", "serviceaccount")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(403))
+			})
+		})
+
 	})
 })


### PR DESCRIPTION
The service account identity header does not have an account number.  As a result, if a record for payload tracker included the account number and the service account identity header did not include the account number, then the track endpoint would return a 403.

Relax track permission checks to only check for the identity header org id to match the org id in the response from payload-tracker.  I believe the account number check was in here due to a transition period where not all records had an org id.  All records should have an org id now.

## What?
Explain what the change is linking any relevant JIRAs or Issues.

## Why?
Consider what business or engineering goal does this PR achieves.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
