### PR TITLE
Modify the subject of the trusted integration test cert

### DIFF
--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const automatedIntegrationTestCert = "68bdb922-9e82-445c-a457-f83c13d23e3d"
+const AutomatedIntegrationTestCertSubject = "68bdb922-9e82-445c-a457-f83c13d23e3d"
 
 type TrackerResponse struct {
 	Data     []Status    `json:"data"`
@@ -146,7 +146,7 @@ func isTrustedIntegrationTestCert(id identity.XRHID) bool {
 	subjectSplit := strings.Split(id.Identity.X509.SubjectDN, "=")
 	subjectDN := subjectSplit[len(subjectSplit)-1]
 
-	return subjectDN == automatedIntegrationTestCert
+	return subjectDN == AutomatedIntegrationTestCertSubject
 }
 
 func isIdAuthorized(identity identity.Identity, orgID string) bool {

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -17,6 +17,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const automatedIntegrationTestCert = "68bdb922-9e82-445c-a457-f83c13d23e3d"
+
 type TrackerResponse struct {
 	Data     []Status    `json:"data"`
 	Duration interface{} `json:"duration"`
@@ -91,15 +93,8 @@ func NewHandler(
 			return
 		}
 
-		var subjectDN string
-		if id.Identity.X509.SubjectDN != "" {
-			subjectSplit := strings.Split(id.Identity.X509.SubjectDN, "=")
-			subjectDN = subjectSplit[len(subjectSplit)-1]
-		}
-
-		if id.Identity.Type != "Associate" && subjectDN != "insightspipelineqe" {
+		if id.Identity.Type != "Associate" && isTrustedIntegrationTestCert(id) == false {
 			if !isIdAuthorized(id.Identity, pt.Data[0].OrgID) {
-
 				incomingRequestID := request_id.GetReqID(r.Context())
 
 				requestLogger.WithFields(logrus.Fields{"requestID": reqID,
@@ -140,6 +135,18 @@ func NewHandler(
 			w.Write(responseBody)
 		}
 	}
+}
+
+func isTrustedIntegrationTestCert(id identity.XRHID) bool {
+
+	if id.Identity.X509.SubjectDN == "" {
+		return false
+	}
+
+	subjectSplit := strings.Split(id.Identity.X509.SubjectDN, "=")
+	subjectDN := subjectSplit[len(subjectSplit)-1]
+
+	return subjectDN == automatedIntegrationTestCert
 }
 
 func isIdAuthorized(identity identity.Identity, orgID string) bool {

--- a/internal/track/track_test.go
+++ b/internal/track/track_test.go
@@ -45,7 +45,16 @@ func makeTestRequest(uri string, request_id string, account string, orgID string
 		ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
 			Identity: identity.Identity{
 				X509: identity.X509{
-					SubjectDN: "/DC=com/DC=redhat/CN=insightspipelineqe",
+					SubjectDN: "/DC=com/DC=redhat/CN=68bdb922-9e82-445c-a457-f83c13d23e3d",
+					IssuerDN:  "CN=redhat",
+				},
+			},
+		})
+	case "untrusted_x509":
+		ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
+			Identity: identity.Identity{
+				X509: identity.X509{
+					SubjectDN: "/DC=com/DC=redhat/CN=im_not_to_be_trusted",
 					IssuerDN:  "CN=redhat",
 				},
 			},
@@ -194,6 +203,18 @@ var _ = Describe("Track", func() {
 				Expect(err).To(BeNil())
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(403))
+			})
+		})
+
+		Context("with an untrusted cert", func() {
+			It("should return HTTP 403", func() {
+				httpmock.RegisterResponder("GET", "http://payload-tracker/v1/payloads/", httpmock.NewStringResponder(200, goodJsonBody))
+				req, err := makeTestRequest("/api/ingress/v1/track/3e3f56e642a248008811cce123b2c0f2", "3e3f56e642a248008811cce123b2c0f2", "6089710", "12346", "untrusted_x509")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(403))
+				Expect(rr.Body).ToNot(BeNil())
+				Expect(rr.Body.String()).To(Equal(""))
 			})
 		})
 

--- a/internal/track/track_test.go
+++ b/internal/track/track_test.go
@@ -45,7 +45,7 @@ func makeTestRequest(uri string, request_id string, account string, orgID string
 		ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
 			Identity: identity.Identity{
 				X509: identity.X509{
-					SubjectDN: "/DC=com/DC=redhat/CN=68bdb922-9e82-445c-a457-f83c13d23e3d",
+					SubjectDN: "/DC=com/DC=redhat/CN=" + AutomatedIntegrationTestCertSubject,
 					IssuerDN:  "CN=redhat",
 				},
 			},


### PR DESCRIPTION
## What?
The trusted integration test cert expired.  I'm struggling to find out how to get it resigned.  In the meantime, this PR modifies the subject of the trusted integration test cert to match a cert we are now using in our tests.  Refactor a bit to try to make it more clear how the permission check is working.

## Why?
Consider what business or engineering goal does this PR achieves.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
