### PR TITLE
Add trusted cert subject for prod

### DIFF
--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -17,7 +17,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const AutomatedIntegrationTestCertSubject = "68bdb922-9e82-445c-a457-f83c13d23e3d"
+const (
+	AutomatedIntegrationTestCertSubjectStage = "68bdb922-9e82-445c-a457-f83c13d23e3d"
+	AutomatedIntegrationTestCertSubjectProd  = "bb2c0145-d185-4cc9-9ba1-2cdbaf90e60f"
+)
 
 type TrackerResponse struct {
 	Data     []Status    `json:"data"`
@@ -146,7 +149,7 @@ func isTrustedIntegrationTestCert(id identity.XRHID) bool {
 	subjectSplit := strings.Split(id.Identity.X509.SubjectDN, "=")
 	subjectDN := subjectSplit[len(subjectSplit)-1]
 
-	return subjectDN == AutomatedIntegrationTestCertSubject
+	return subjectDN == AutomatedIntegrationTestCertSubjectStage || subjectDN == AutomatedIntegrationTestCertSubjectProd
 }
 
 func isIdAuthorized(identity identity.Identity, orgID string) bool {

--- a/internal/track/track_test.go
+++ b/internal/track/track_test.go
@@ -45,7 +45,7 @@ func makeTestRequest(uri string, request_id string, account string, orgID string
 		ctx = context.WithValue(ctx, identity.Key, identity.XRHID{
 			Identity: identity.Identity{
 				X509: identity.X509{
-					SubjectDN: "/DC=com/DC=redhat/CN=" + AutomatedIntegrationTestCertSubject,
+					SubjectDN: "/DC=com/DC=redhat/CN=" + AutomatedIntegrationTestCertSubjectStage,
 					IssuerDN:  "CN=redhat",
 				},
 			},


### PR DESCRIPTION
Add trusted cert subject for prod

Stage and prod use the same CA to sign the certs.  However, the gateway reaches out to candlepin to "bless" the certs and stage and prod use a different candlepin instance.