### PR TITLE
Making image building more restrictive

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.docker
+.podman
+.kube
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
 
 WORKDIR /go/src/app
-COPY . .
+
+COPY cmd cmd
+
+COPY internal internal
+
+COPY go.mod go.mod
+
+COPY go.sum go.sum
+
+COPY licenses licenses
 
 USER 0
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -16,7 +16,18 @@ if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
     exit 1
 fi
 
-DOCKER_CONF="$PWD/.docker"
+# Create tmp dir to store data in during job run (do NOT store in $WORKSPACE)
+export TMP_JOB_DIR=$(mktemp -d -p "$HOME" -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}-XXXXXX")
+echo "job tmp dir location: $TMP_JOB_DIR"
+
+function job_cleanup() {
+    echo "cleaning up job tmp dir: $TMP_JOB_DIR"
+    rm -fr $TMP_JOB_DIR
+}
+
+trap job_cleanup EXIT ERR SIGINT SIGTERM
+
+DOCKER_CONF="$TMP_JOB_DIR/.docker"
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io

--- a/development/local-dev-start.yml
+++ b/development/local-dev-start.yml
@@ -11,7 +11,7 @@ services:
   kafka:
     image: confluentinc/cp-kafka
     ports:
-      - 29092:29092
+      - "29092:29092"
     depends_on:
       - zookeeper
     environment:
@@ -50,7 +50,7 @@ services:
     #image: quay.io/cloudservices/insights-ingress:latest
     image: ingress:latest
     ports:
-      - 8080:3000
+      - "3000:3000"
     mem_limit: 512M
     environment:
       - INGRESS_STAGEBUCKET=insights-upload-perma


### PR DESCRIPTION
## What?

-  Making the docker image build more restrictive.
- Updated local docker-compose file for easier spin up and testing

Tested image build by doing the following:
- Created an ingress image by doing `docker build -t ingress . -f Dockerfile --no-cache`
- Then did `docker-compose -f development/local-dev-start.yml up` to spin everything up
- Finally tested by doing `make run-upload-test`

## Why?
Consider what business or engineering goal does this PR achieves.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
