### PR TITLE
Add filesystem based support for deployments without minio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.txt
 .scannerwork
 .sonar/sonar-scanner.properties
 gopath
+development/filebased/

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,22 @@ include development/.env
 
 BINARY=insights-ingress-go
 DATA_DIR=$(PWD)/development/filebased
+TAGS_OPTS=
+BUILD_OPTS=
+ifeq ($(shell uname -s), Darwin)
+	TAGS_OPTS=-tags dynamic
+	BUILD_OPTS=-ldflags -s -tags dynamic
+endif
 
 .PHONY: $(BINARY)
 
 build: $(BINARY)
 
 $(BINARY):
-	go build -ldflags -s -tags dynamic -o $(BINARY) cmd/insights-ingress/main.go
+	go build ${BUILD_OPTS} -o $(BINARY) cmd/insights-ingress/main.go
 
 test:
-	go test -tags dynamic -p 1 -v ./...
+	go test ${TAGS_OPTS} -p 1 -v ./...
 
 setup-filebased:
 	mkdir -p $(DATA_DIR)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,7 @@ func Get() *IngressConfig {
 	options.SetDefault("Deny_Listed_OrgIDs", []string{})
 	options.SetDefault("Debug", false)
 	options.SetDefault("DebugUserAgent", `unspecified`)
+	options.SetDefault("ServiceBaseURL", "http://localhost:3000")
 	options.SetDefault("StagerImplementation", "s3")
 	options.SetEnvPrefix("INGRESS")
 	options.AutomaticEnv()
@@ -203,14 +204,8 @@ func Get() *IngressConfig {
 		options.SetDefault("WebPort", 3000)
 		options.SetDefault("MetricsPort", 8080)
 		// Storage
-		stagerImplementation := GetStagerImplementation(options.GetString("StagerImplementation"), options.GetString("StorageFileSystemPath"))
-		options.SetDefault("StagerImplementation", stagerImplementation)
-		if stagerImplementation == "s3" {
-			options.SetDefault("StageBucket", "available")
-			options.SetDefault("StorageRegion", "")
-		} else {
-			options.SetDefault("ServiceBaseURL", "http://localhost:3000")
-		}
+		options.SetDefault("StageBucket", "available")
+		options.SetDefault("StorageRegion", "")
 		// Cloudwatch
 		options.SetDefault("LogGroup", "platform-dev")
 		options.SetDefault("AwsRegion", "us-east-1")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,8 @@ type IngressConfig struct {
 	DenyListedOrgIDs     []string
 	Debug                bool
 	DebugUserAgent       *regexp.Regexp
+	ServiceBaseURL       string
+	StagerImplementation string
 }
 
 type KafkaCfg struct {
@@ -55,12 +57,13 @@ type KafkaSSLCfg struct {
 }
 
 type StorageCfg struct {
-	StageBucket      string
-	StorageEndpoint  string
-	StorageAccessKey string
-	StorageSecretKey string
-	UseSSL           bool
-	StorageRegion    string
+	StageBucket           string
+	StorageEndpoint       string
+	StorageAccessKey      string
+	StorageSecretKey      string
+	UseSSL                bool
+	StorageRegion         string
+	StorageFileSystemPath string
 }
 
 type LoggingCfg struct {
@@ -76,6 +79,21 @@ func GetTopic(topic string) string {
 		return rhiconfig.KafkaTopics[topic].Name
 	}
 	return topic
+}
+
+func GetStagerImplementation(stagerImplementation string, stageFileSystemPath string) string {
+	if !clowder.IsClowderEnabled() {
+		lowerStagerImplementation := strings.ToLower(stagerImplementation)
+		if lowerStagerImplementation == "filebased" {
+			if len(stageFileSystemPath) != 0 {
+				err := os.MkdirAll(stageFileSystemPath, os.ModePerm)
+				if err == nil {
+					return "filebased"
+				}
+			}
+		}
+	}
+	return "s3"
 }
 
 // Get provides the IngressConfig
@@ -113,6 +131,7 @@ func Get() *IngressConfig {
 	options.SetDefault("Deny_Listed_OrgIDs", []string{})
 	options.SetDefault("Debug", false)
 	options.SetDefault("DebugUserAgent", `unspecified`)
+	options.SetDefault("StagerImplementation", "s3")
 	options.SetEnvPrefix("INGRESS")
 	options.AutomaticEnv()
 	kubenv := viper.New()
@@ -184,8 +203,14 @@ func Get() *IngressConfig {
 		options.SetDefault("WebPort", 3000)
 		options.SetDefault("MetricsPort", 8080)
 		// Storage
-		options.SetDefault("StageBucket", "available")
-		options.SetDefault("StorageRegion", "")
+		stagerImplementation := GetStagerImplementation(options.GetString("StagerImplementation"), options.GetString("StorageFileSystemPath"))
+		options.SetDefault("StagerImplementation", stagerImplementation)
+		if stagerImplementation == "s3" {
+			options.SetDefault("StageBucket", "available")
+			options.SetDefault("StorageRegion", "")
+		} else {
+			options.SetDefault("ServiceBaseURL", "http://localhost:3000")
+		}
 		// Cloudwatch
 		options.SetDefault("LogGroup", "platform-dev")
 		options.SetDefault("AwsRegion", "us-east-1")
@@ -221,12 +246,13 @@ func Get() *IngressConfig {
 			KafkaSecurityProtocol: options.GetString("KafkaSecurityProtocol"),
 		},
 		StorageConfig: StorageCfg{
-			StageBucket:      options.GetString("StageBucket"),
-			StorageEndpoint:  options.GetString("MinioEndpoint"),
-			StorageAccessKey: options.GetString("MinioAccessKey"),
-			StorageSecretKey: options.GetString("MinioSecretKey"),
-			UseSSL:           options.GetBool("UseSSL"),
-			StorageRegion:    options.GetString("StorageRegion"),
+			StageBucket:           options.GetString("StageBucket"),
+			StorageEndpoint:       options.GetString("MinioEndpoint"),
+			StorageAccessKey:      options.GetString("MinioAccessKey"),
+			StorageSecretKey:      options.GetString("MinioSecretKey"),
+			UseSSL:                options.GetBool("UseSSL"),
+			StorageRegion:         options.GetString("StorageRegion"),
+			StorageFileSystemPath: options.GetString("StorageFileSystemPath"),
 		},
 		LoggingConfig: LoggingCfg{
 			LogGroup:           options.GetString("logGroup"),
@@ -235,6 +261,8 @@ func Get() *IngressConfig {
 			AwsAccessKeyId:     options.GetString("AwsAccessKeyId"),
 			AwsSecretAccessKey: options.GetString("AwsSecretAccessKey"),
 		},
+		ServiceBaseURL:       options.GetString("ServiceBaseURL"),
+		StagerImplementation: options.GetString("StagerImplementation"),
 	}
 
 	if options.IsSet("KafkaUsername") {

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -1,0 +1,31 @@
+package download
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"github.com/go-chi/chi"
+	"github.com/redhatinsights/insights-ingress-go/internal/config"
+	"github.com/redhatinsights/insights-ingress-go/internal/stage/filebased"
+)
+
+// NewHandler returns a http handler configured with a Pipeline
+func NewHandler(cfg config.IngressConfig) http.HandlerFunc {
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		downloadID := chi.URLParam(r, "requestID")
+		fileName, err := filebased.GetFileStorageName(downloadID)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("Bad Request: Invalid request ID"))
+			return
+		} else {
+			filePath := filepath.Join(cfg.StorageConfig.StorageFileSystemPath, fileName)
+			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s",
+				fileName))
+			w.Header().Set("Content-Type", "application/gzip")
+			http.ServeFile(w, r, filePath)
+		}
+	}
+}

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -3,7 +3,6 @@ package download
 import (
 	"fmt"
 	"net/http"
-	"path/filepath"
 
 	"github.com/go-chi/chi"
 	"github.com/redhatinsights/insights-ingress-go/internal/config"
@@ -15,13 +14,12 @@ func NewHandler(cfg config.IngressConfig) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		downloadID := chi.URLParam(r, "requestID")
-		fileName, err := filebased.GetFileStorageName(downloadID)
+		fileName, filePath, err := filebased.GetFileStorageName(downloadID, cfg.StorageConfig.StorageFileSystemPath)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("Bad Request: Invalid request ID"))
 			return
 		} else {
-			filePath := filepath.Join(cfg.StorageConfig.StorageFileSystemPath, fileName)
 			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s",
 				fileName))
 			w.Header().Set("Content-Type", "application/gzip")

--- a/internal/download/download_suite_test.go
+++ b/internal/download/download_suite_test.go
@@ -1,0 +1,17 @@
+package download_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/insights-ingress-go/internal/config"
+	l "github.com/redhatinsights/insights-ingress-go/internal/logger"
+)
+
+func TestDownload(t *testing.T) {
+	cfg := config.Get()
+	RegisterFailHandler(Fail)
+	l.InitLogger(cfg)
+	RunSpecs(t, "Test Download Suite")
+}

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -1,0 +1,77 @@
+package download_test
+
+import (
+	"github.com/go-chi/chi"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/insights-ingress-go/internal/config"
+	"github.com/redhatinsights/insights-ingress-go/internal/download"
+)
+
+var _ = Describe("Download", func() {
+	var (
+		configuration *config.IngressConfig
+		tmpDir        string
+		testFile      string
+		router        *chi.Mux
+		handler       http.HandlerFunc
+		recorder      *httptest.ResponseRecorder
+		request       *http.Request
+	)
+
+	BeforeEach(func() {
+		var err error
+		configuration = config.Get()
+		tmpDir, err = os.MkdirTemp("", "testfiles")
+		configuration.StorageConfig.StorageFileSystemPath = tmpDir
+		Expect(err).NotTo(HaveOccurred())
+		router = chi.NewRouter()
+
+		handler = download.NewHandler(*configuration)
+		router.Get("/download/{requestID}", handler)
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	It("should serve the file content", func() {
+		testFile = filepath.Join(tmpDir, "1234.tar.gz")
+		err := os.WriteFile(testFile, []byte("Test file content"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		request, err = http.NewRequest("GET", "/download/1234", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a response recorder
+		recorder = httptest.NewRecorder()
+
+		// Serve the request
+		router.ServeHTTP(recorder, request)
+
+		// Assert the response
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		Expect(recorder.Body.String()).To(Equal("Test file content"))
+	})
+
+	It("should return 404 if the file does not exist", func() {
+		recorder = httptest.NewRecorder()
+		request, _ = http.NewRequest("GET", "/download/99999", nil)
+
+		router.ServeHTTP(recorder, request)
+		Expect(recorder.Code).To(Equal(http.StatusNotFound))
+	})
+
+	It("should return 400 if the request ID is invalid", func() {
+		recorder = httptest.NewRecorder()
+		request, _ = http.NewRequest("GET", "/download/--", nil)
+
+		router.ServeHTTP(recorder, request)
+		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+	})
+})

--- a/internal/stage/filebased/filebased.go
+++ b/internal/stage/filebased/filebased.go
@@ -17,7 +17,7 @@ type FileBasedStager struct {
 	BaseURL   string
 }
 
-func FilterAlphanumeric(s string) string {
+func filterAlphanumeric(s string) string {
 	var sb strings.Builder
 	for _, r := range s {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
@@ -27,23 +27,23 @@ func FilterAlphanumeric(s string) string {
 	return sb.String()
 }
 
-func GetFileStorageName(requestID string) (string, error) {
-	key := FilterAlphanumeric(requestID)
+func GetFileStorageName(requestID string, storageDir string) (string, string, error) {
+	key := filterAlphanumeric(requestID)
 	if len(key) == 0 {
-		return "", errors.New("bad request id format")
+		return "", "", errors.New("bad request id format")
 	}
 	fileName := key + ".tar.gz"
-	return fileName, nil
+	filePath := filepath.Join(storageDir, fileName)
+	return fileName, filePath, nil
 }
 
 // Stage stores the file in filesystem storage and returns a presigned url
 func (s *FileBasedStager) Stage(in *stage.Input) (string, error) {
-	fileName, err := GetFileStorageName(in.Key)
+	_, filePath, err := GetFileStorageName(in.Key, s.StagePath)
 	if err != nil {
 		return "", err
 	}
 	file := in.Payload
-	filePath := filepath.Join(s.StagePath, fileName)
 	dst, err := os.Create(filePath)
 	if err != nil {
 		return "", err

--- a/internal/stage/filebased/filebased.go
+++ b/internal/stage/filebased/filebased.go
@@ -1,0 +1,64 @@
+package filebased
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/redhatinsights/insights-ingress-go/internal/stage"
+)
+
+// Stager provides the mechanism to stage a payload to the file system
+type FileBasedStager struct {
+	StagePath string
+	BaseURL   string
+}
+
+func FilterAlphanumeric(s string) string {
+	var sb strings.Builder
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+func GetFileStorageName(requestID string) (string, error) {
+	key := FilterAlphanumeric(requestID)
+	if len(key) == 0 {
+		return "", errors.New("bad request id format")
+	}
+	fileName := key + ".tar.gz"
+	return fileName, nil
+}
+
+// Stage stores the file in filesystem storage and returns a presigned url
+func (s *FileBasedStager) Stage(in *stage.Input) (string, error) {
+	fileName, err := GetFileStorageName(in.Key)
+	if err != nil {
+		return "", err
+	}
+	file := in.Payload
+	filePath := filepath.Join(s.StagePath, fileName)
+	dst, err := os.Create(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer dst.Close()
+
+	_, err = io.Copy(dst, file)
+	if err != nil {
+		return "", err
+	}
+	return s.GetURL(in.Key)
+}
+
+// GetURL retrieves a presigned url from filesystem storage
+func (s *FileBasedStager) GetURL(requestID string) (string, error) {
+	fileURL := s.BaseURL + "/download/" + requestID
+	return fileURL, nil
+}

--- a/internal/stage/filebased/filebased_suite_test.go
+++ b/internal/stage/filebased/filebased_suite_test.go
@@ -1,0 +1,20 @@
+package filebased_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/insights-ingress-go/internal/config"
+	l "github.com/redhatinsights/insights-ingress-go/internal/logger"
+)
+
+func TestFileBased(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := config.Get()
+	cfg.StagerImplementation = "filebased"
+	cfg.StorageConfig.StorageFileSystemPath = tempDir
+	RegisterFailHandler(Fail)
+	l.InitLogger(cfg)
+	RunSpecs(t, "Test File Based Suite")
+}

--- a/internal/stage/filebased/filebased_test.go
+++ b/internal/stage/filebased/filebased_test.go
@@ -1,0 +1,188 @@
+package filebased_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
+	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
+
+	"github.com/redhatinsights/insights-ingress-go/internal/announcers"
+	"github.com/redhatinsights/insights-ingress-go/internal/config"
+	"github.com/redhatinsights/insights-ingress-go/internal/stage/filebased"
+	. "github.com/redhatinsights/insights-ingress-go/internal/upload"
+	"github.com/redhatinsights/insights-ingress-go/internal/validators"
+)
+
+type FilePart struct {
+	Name        string
+	Content     string
+	ContentType string
+}
+
+func setTime() time.Time {
+	return time.Now()
+}
+
+func makeMultipartRequest(uri string, parts ...*FilePart) (*http.Request, error) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	requestId := "e6b06142958942139a5e1e2f513c448b"
+	for _, filePart := range parts {
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition",
+			fmt.Sprintf(`form-data; name="%s"; filename="%s.txt"`, filePart.Name, filePart.Name))
+		h.Set("Content-Type", filePart.ContentType)
+
+		part, err := writer.CreatePart(h)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = io.Copy(part, strings.NewReader(filePart.Content))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err := writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", uri, body)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	ctx = identity.WithIdentity(ctx, identity.XRHID{
+		Identity: identity.Identity{
+			AccountNumber: "540155",
+			OrgID:         "12345",
+			Internal: identity.Internal{
+				OrgID: "12345",
+			},
+		},
+	})
+
+	req.Header.Add("x-rh-insights-request-id", requestId)
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req, nil
+}
+
+func makeTestRequest(uri string, testType string, tenant string, body string) (*http.Request, error) {
+
+	var req *http.Request
+	var err error
+
+	requestId := "e6b06142958942139a5e1e2f513c448b"
+
+	if testType == "new" {
+		formData := url.Values{"test": {"test"}}
+		req, err = http.NewRequest("POST", uri, strings.NewReader(formData.Encode()))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Add("Content-Length", strconv.Itoa(len(formData.Encode())))
+	}
+
+	if testType == "legacy" {
+		req, err = http.NewRequest("POST", uri, strings.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Content-Length", strconv.Itoa(len(body)))
+	}
+
+	ctx := context.Background()
+	if tenant == "anemic" {
+		ctx = identity.WithIdentity(ctx, identity.XRHID{
+			Identity: identity.Identity{
+				OrgID: "12345",
+				Internal: identity.Internal{
+					OrgID: "12345",
+				},
+			},
+		})
+	} else {
+		ctx = identity.WithIdentity(ctx, identity.XRHID{
+			Identity: identity.Identity{
+				AccountNumber: "540155",
+				OrgID:         "12345",
+				Internal: identity.Internal{
+					OrgID: "12345",
+				},
+			},
+		})
+	}
+
+	req.Header.Add("x-rh-insights-request-id", requestId)
+	req = req.WithContext(ctx)
+	return req, nil
+
+}
+
+var _ = Describe("Upload", func() {
+	var (
+		configuration *config.IngressConfig
+		stager        *filebased.FileBasedStager
+		tracker       announcers.Announcer
+		validator     *validators.Fake
+		handler       http.Handler
+		rr            *httptest.ResponseRecorder
+
+		goodJsonBody       = `{"request_id":"e6b06142958942139a5e1e2f513c448b","upload":{"account_number":"540155","org_id":"12345"}}`
+		goodAnemicJsonBody = `{"request_id":"e6b06142958942139a5e1e2f513c448b","upload":{"org_id":"12345"}}`
+	)
+
+	BeforeEach(func() {
+
+		configuration = config.Get()
+		stager = &filebased.FileBasedStager{StagePath: configuration.StorageConfig.StorageFileSystemPath, BaseURL: configuration.ServiceBaseURL}
+		validator = &validators.Fake{}
+		tracker = &announcers.Fake{}
+
+		rr = httptest.NewRecorder()
+		handler = NewHandler(stager, validator, tracker, *configuration)
+		reqConfiguredHandlerFunc := request_id.ConfiguredRequestID("x-rh-insights-request-id")
+		handler = reqConfiguredHandlerFunc(handler)
+	})
+
+	Describe("Post to endpoint", func() {
+		Context("with test data for test-connection", func() {
+			It("should return HTTP 200", func() {
+				req, err := makeTestRequest("/api/ingress/v1/upload", "new", "", "")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(200))
+				Expect(rr.Body.String()).To(Equal(goodJsonBody))
+			})
+		})
+
+		Context("with missing account number in identity header", func() {
+			It("should return HTTP 200", func() {
+				req, err := makeTestRequest("/api/ingress/v1/upload", "new", "anemic", "")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(200))
+				Expect(rr.Body.String()).To(Equal(goodAnemicJsonBody))
+			})
+		})
+	})
+})

--- a/internal/stage/s3compat/s3compat.go
+++ b/internal/stage/s3compat/s3compat.go
@@ -10,13 +10,13 @@ import (
 )
 
 // Stager provides the mechanism to stage a payload via aws S3
-type Stager struct {
+type S3Stager struct {
 	Bucket string
 	Client *minio.Client
 }
 
 // GetClient gets the s3 compatible client info
-func GetClient(cfg *config.IngressConfig, stager *Stager) stage.Stager {
+func GetClient(cfg *config.IngressConfig, stager *S3Stager) stage.Stager {
 	var endpoint string
 	storageCfg := cfg.StorageConfig
 	if storageCfg.StorageEndpoint == "" {
@@ -38,7 +38,7 @@ func GetClient(cfg *config.IngressConfig, stager *Stager) stage.Stager {
 }
 
 // Stage stores the file in s3 compatible storage and returns a presigned url
-func (s *Stager) Stage(in *stage.Input) (string, error) {
+func (s *S3Stager) Stage(in *stage.Input) (string, error) {
 	bucketName := s.Bucket
 	objectName := in.Key
 	object := in.Payload
@@ -64,7 +64,7 @@ func (s *Stager) Stage(in *stage.Input) (string, error) {
 }
 
 // GetURL retrieves a presigned url from s3 compatible storage
-func (s *Stager) GetURL(requestID string) (string, error) {
+func (s *S3Stager) GetURL(requestID string) (string, error) {
 	url, err := s.Client.PresignedGetObject(s.Bucket, requestID, time.Second*24*60*60, nil)
 	if err != nil {
 		return "", errors.New("Failed to generate presigned url: " + err.Error())


### PR DESCRIPTION
## What?
Explain what the change is linking any relevant JIRAs or Issues.
Add filesystem based support for deployments without minio
https://issues.redhat.com/browse/RHINENG-16283

## Why?
Consider what business or engineering goal does this PR achieves.
Some upcoming deployments will not be able to rely on an s3 compatible storage backend

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

- Added an interface implementation of the Stager that store uploads on the filesystem when the filesystem configuration environment variable is supplied
- Added an API to download the upload from the filesystem replacing the s3 download http endpoint that is only mounted when the filesystem based environment variable is supplied

## Testing
Did you add any tests for the change?
Tests were added to test uploads when the filesystem configuration environment variable is supplied

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
