### PR TITLE
[RHCLOUD-41106] bump Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,6 @@ FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
 
 WORKDIR /go/src/app
 
-# The current ubi9 image does not include Go 1.24, so we specify it.
-# Adding "auto" will allow a newer version to be downloaded if specified in go.mod
-ARG GOTOOLCHAIN=go1.24.3+auto
-
 COPY cmd cmd
 
 COPY internal internal

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/insights-ingress-go
 
-go 1.24.3
+go 1.24.4
 
 require (
 	github.com/aws/aws-sdk-go v1.55.6


### PR DESCRIPTION
## What?
https://issues.redhat.com/browse/RHCLOUD-41106

## Why?
See linked ticket

## How?
Bump Go version to 1.24.4.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
