### PR TITLE
Add Assisted Installer Chat Bot as separate upload type

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -95,7 +95,7 @@ parameters:
 - name: INGRESS_STAGEBUCKET
   value: insights-upload-perma
 - name: INGRESS_VALID_UPLOAD_TYPES
-  value: advisor,compliance,hccm,qpc,rhv,tower,leapp-reporting,xavier,mkt,playbook,playbook-sat,resource-optimization,malware-detection,pinakes,assisted-installer,runtimes-java-general,openshift,tasks,automation-hub,aap-billing-controller,aap-event-driven-ansible,ols
+  value: advisor,compliance,hccm,qpc,rhv,tower,leapp-reporting,xavier,mkt,playbook,playbook-sat,resource-optimization,malware-detection,pinakes,assisted-installer,runtimes-java-general,openshift,tasks,automation-hub,aap-billing-controller,aap-event-driven-ansible,ols,ocm-assisted-chat
 - name: INGRESS_DEFAULTMAXSIZE
   value: '104857600'
 - name: INGRESS_MAXSIZEMAP


### PR DESCRIPTION
We will be using the lightspeed data exporter from @onmete in our own lightspeed deployment.

## What?
The OpenShift Assisted Installer Chat Bot has its own lightspeed deployment and we want to collect feedback/transcript data using @onmete 's exporter.
https://issues.redhat.com/browse/MGMT-21288

