### PR TITLE
fix: Improve error message for missing bucket

### DIFF
--- a/internal/stage/s3compat/s3compat.go
+++ b/internal/stage/s3compat/s3compat.go
@@ -58,7 +58,7 @@ func (s *S3Stager) Stage(in *stage.Input) (string, error) {
 		},
 	)
 	if err != nil {
-		return "", errors.New("Failed to upload to storage" + err.Error())
+		return "", errors.New("Failed to upload '" + bucketName + "' to storage: " + err.Error())
 	}
 	return s.GetURL(in.Key)
 }


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-41854

## What?
* When required bucket was missing, then formatting of generated error message was wrong and it did not contain important information about bucket name
* It is related to GitHub issue #563 and RHCLOUD-41854

## Why?
Improve error message

## How?
Simple fix of generated error message

## Testing
No need to test it

## Anything Else?
When the bucket `insights-upload-perma` does not exists. You can delete it on http://localhost:9990/, then it is possible to test it using `make run-upload-test`.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
