### PR TITLE
Add openstack-lightspeed (rhos-lightspeed) as a valid upload type

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -95,7 +95,7 @@ parameters:
 - name: INGRESS_STAGEBUCKET
   value: insights-upload-perma
 - name: INGRESS_VALID_UPLOAD_TYPES
-  value: advisor,compliance,hccm,qpc,rhv,tower,leapp-reporting,xavier,mkt,playbook,playbook-sat,resource-optimization,malware-detection,pinakes,assisted-installer,runtimes-java-general,openshift,tasks,automation-hub,aap-billing-controller,aap-event-driven-ansible,ols,ocm-assisted-chat
+  value: advisor,compliance,hccm,qpc,rhv,tower,leapp-reporting,xavier,mkt,playbook,playbook-sat,resource-optimization,malware-detection,pinakes,assisted-installer,runtimes-java-general,openshift,tasks,automation-hub,aap-billing-controller,aap-event-driven-ansible,ols,ocm-assisted-chat,rhos-lightspeed
 - name: INGRESS_DEFAULTMAXSIZE
   value: '104857600'
 - name: INGRESS_MAXSIZEMAP


### PR DESCRIPTION
## What?
Add openstack-lightspeed as a valid upload type to allow define service in content-type application/vnd.redhat.rhos-lightspeed.periodic+tar during upload.

https://issues.redhat.com/browse/OSPRH-17335

## Why?
Data collection from openstack-lightspeed instances. We want to leverage ingress/insights-storage-broker capabilities to store the incoming archives directly and being able to identify them separately from ols and other lightspeed services.

## How?
We will be using the [lightspeed data exporter](https://github.com/lightspeed-core/lightspeed-to-dataverse-exporter) in the openstack-lightspeed deployment, so we are adding rhos-lightspeed as valid upload type.

## Testing
No

## Anything Else?
No

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
