### PR TITLE
Add non-Clowder configuration support for on-prem deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 insights-ingress-go
 .idea
+.vscode
 coverage.txt
 .scannerwork
 .sonar/sonar-scanner.properties

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ cloud.redhat.com, the customer should engage with support.
 
 Golang >= 1.21
 
+**macOS additional dependencies (for running with `-tags dynamic`):**
+
+```bash
+brew install pkg-config librdkafka
+```
+
+These are required for building with the `dynamic` tag, which links against the system librdkafka library for Kafka support.
+
 #### Launching the Service
 
 Compile the source code into a go binary:

--- a/development/local-dev-start.yml
+++ b/development/local-dev-start.yml
@@ -10,6 +10,7 @@ services:
       - ZOOKEEPER_SERVER_ID=1
   kafka:
     image: confluentinc/cp-kafka
+    restart: always
     ports:
       - "29092:29092"
     depends_on:
@@ -54,7 +55,7 @@ services:
       /bin/sh -c "
       export MC_HOST_myminio=http://${MINIO_ACCESS_KEY}:${MINIO_SECRET_KEY}@minio:9000;
       /usr/bin/mc mb --ignore-existing myminio/insights-upload-perma;
-      /usr/bin/mc policy set public myminio/insights-upload-perma;
+      /usr/bin/mc anonymous set public myminio/insights-upload-perma;
       "
   ingress:
     #image: quay.io/cloudservices/insights-ingress:latest

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,15 +203,18 @@ func Get() *IngressConfig {
 		// Ports
 		options.SetDefault("WebPort", 3000)
 		options.SetDefault("MetricsPort", 8080)
-		// Storage
+		// Storage (MinIO/S3-compatible)
 		options.SetDefault("StageBucket", "available")
+		options.SetDefault("MinioEndpoint", "")
+		options.SetDefault("MinioAccessKey", "")
+		options.SetDefault("MinioSecretKey", "")
 		options.SetDefault("StorageRegion", "")
-		// Cloudwatch
-		options.SetDefault("LogGroup", "platform-dev")
-		options.SetDefault("AwsRegion", "us-east-1")
 		options.SetDefault("UseSSL", false)
-		options.SetDefault("AwsAccessKeyId", os.Getenv("CW_AWS_ACCESS_KEY_ID"))
-		options.SetDefault("AwsSecretAccessKey", os.Getenv("CW_AWS_SECRET_ACCESS_KEY"))
+		// Cloudwatch (disabled by default for on-prem)
+		options.SetDefault("LogGroup", "")
+		options.SetDefault("AwsRegion", "")
+		options.SetDefault("AwsAccessKeyId", "")
+		options.SetDefault("AwsSecretAccessKey", "")
 	}
 
 	IngressCfg := &IngressConfig{


### PR DESCRIPTION
## What?
- Add MinIO/S3 storage defaults (MinioEndpoint, MinioAccessKey, MinioSecretKey) to non-Clowder config path, enabling environment variable configuration via INGRESS_MINIO* variables
- Disable AWS CloudWatch defaults for on-prem (empty LogGroup, AwsRegion, AwsAccessKeyId, AwsSecretAccessKey)
- Fix local-dev-start.yml for compatibility with newer versions:
  - Update MinIO client commands (mc alias/anonymous vs deprecated config/policy)
  - Add restart:always to Kafka for startup reliability
- Add .vscode to .gitignore

## Why?
The change is needed to allow using the ingress-go service for on-prem deployment.

## How?
Simply by allowing addition items to be configured instead of relying on hard-coded values.

## Testing
Local deployment fixed and running.

## Anything Else?
No.


