### PR TITLE
Support Kafka SASL/TLS in non-Clowder (on-prem) mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,8 +150,17 @@ func Get() *IngressConfig {
 	options.SetDefault("DebugUserAgent", `unspecified`)
 	options.SetDefault("ServiceBaseURL", "http://localhost:3000")
 	options.SetDefault("StagerImplementation", "s3")
+	// Kafka SASL/TLS defaults — AutomaticEnv resolves these via the INGRESS_ prefix
+	// (e.g. INGRESS_KAFKAUSERNAME, INGRESS_SASLMECHANISM, INGRESS_KAFKACA).
+	// In Clowder mode, Set() overrides these with values from the Clowder config.
+	options.SetDefault("KafkaUsername", "")
+	options.SetDefault("KafkaPassword", "")
+	options.SetDefault("SASLMechanism", "")
+	options.SetDefault("KafkaCA", "")
+
 	options.SetEnvPrefix("INGRESS")
 	options.AutomaticEnv()
+
 	kubenv := viper.New()
 	kubenv.SetDefault("Openshift_Build_Commit", "notrunninginopenshift")
 	kubenv.AutomaticEnv()

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -58,12 +58,13 @@ func Producer(in chan validators.ValidationMessage, config *ProducerConfig) {
 		"go.delivery.reports": config.KafkaDeliveryReports,
 	}
 
+	_ = configMap.SetKey("security.protocol", config.KafkaSecurityProtocol)
+
 	if config.CA != "" {
 		_ = configMap.SetKey("ssl.ca.location", config.CA)
 	}
 
 	if config.SASLMechanism != "" {
-		_ = configMap.SetKey("security.protocol", config.KafkaSecurityProtocol)
 		_ = configMap.SetKey("sasl.mechanism", config.SASLMechanism)
 		_ = configMap.SetKey("sasl.username", config.Username)
 		_ = configMap.SetKey("sasl.password", config.Password)


### PR DESCRIPTION
## Summary

- Register `KafkaUsername`, `KafkaPassword`, `SASLMechanism`, and `KafkaCA` as viper defaults so `AutomaticEnv` resolves them via the `INGRESS_` prefix (e.g. `INGRESS_KAFKAUSERNAME`, `INGRESS_KAFKAPASSWORD`, `INGRESS_SASLMECHANISM`, `INGRESS_KAFKACA`). In Clowder mode, `Set()` from the Clowder config takes priority.
- Move `security.protocol` out of the SASL-only block in the Kafka producer so TLS-only mode (`SSL` without SASL) works correctly.

## Motivation

The on-prem Helm chart (cost-onprem) needs to configure Kafka SASL/TLS via environment variables. Previously, the SASL credentials and CA cert path were only populated from the Clowder config — there was no env var path for non-Clowder deployments. Additionally, `security.protocol` was only set when SASL was enabled, preventing TLS-only (`SSL`) mode from working.

## Part of

- Helm chart: https://github.com/insights-onprem/cost-onprem-chart/pull/118

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Deploy with `INGRESS_KAFKASECURITYPROTOCOL=SASL_SSL`, `INGRESS_SASLMECHANISM`, `INGRESS_KAFKAUSERNAME`, `INGRESS_KAFKAPASSWORD` and verify Kafka connectivity
- [ ] Deploy with `INGRESS_KAFKASECURITYPROTOCOL=SSL` and `INGRESS_KAFKACA` (TLS-only, no SASL) and verify Kafka connectivity
- [ ] Deploy without any SASL/TLS env vars and verify default PLAINTEXT behavior is unchanged