### PR TITLE
Set Content-Type before WriteHeader in upload response

### DIFF
--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -126,7 +126,6 @@ func handleTestRequest(reqID string, identity identity.Identity, w http.Response
 		Account:   identity.AccountNumber,
 		OrgID:     identity.OrgID,
 	}
-	w.WriteHeader(http.StatusOK)
 	jsonBody, err := createUploadResponse(mockVr)
 	if err != nil {
 		logerr("Unable to marshal JSON response body", err)
@@ -134,6 +133,8 @@ func handleTestRequest(reqID string, identity identity.Identity, w http.Response
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	w.Write(jsonBody)
 }
 
@@ -320,12 +321,12 @@ func NewHandler(
 		}
 
 		metadata, err := readMetadataPart(r)
+		w.Header().Set("Content-Type", "application/json")
 		if vr.Service == "advisor" && metadata == nil {
 			w.WriteHeader(http.StatusCreated)
 		} else {
 			w.WriteHeader(http.StatusAccepted)
 		}
-		w.Header().Set("Content-Type", "application/json")
 		w.Write(jsonBody)
 	}
 }

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -159,6 +159,15 @@ var _ = Describe("Upload", func() {
 		Expect(rr.Body).ToNot(BeNil())
 	}
 
+	var boilerWithContentType = func(code int, expectedContentType string, parts ...*FilePart) {
+		req, err := makeMultipartRequest("/api/ingress/v1/upload", parts...)
+		Expect(err).To(BeNil())
+		handler.ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(code))
+		Expect(rr.Body).ToNot(BeNil())
+		Expect(rr.Header().Get("Content-Type")).To(Equal(expectedContentType))
+	}
+
 	BeforeEach(func() {
 
 		stager = &stage.Fake{ShouldError: false}
@@ -182,6 +191,13 @@ var _ = Describe("Upload", func() {
 				handler.ServeHTTP(rr, req)
 				Expect(rr.Code).To(Equal(200))
 				Expect(rr.Body.String()).To(Equal(goodJsonBody))
+			})
+
+			It("should return Content-Type application/json", func() {
+				req, err := makeTestRequest("/api/ingress/v1/upload", "new", "", "")
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Header().Get("Content-Type")).To(Equal("application/json"))
 			})
 		})
 
@@ -224,11 +240,28 @@ var _ = Describe("Upload", func() {
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.advisor.test"})
 			})
+
+			It("should return Content-Type application/json on 201", func() {
+				boilerWithContentType(http.StatusCreated, "application/json", &FilePart{
+					Name:        "file",
+					Content:     "testing",
+					ContentType: "application/vnd.redhat.advisor.test"})
+			})
 		})
 
 		Context("with no metadata from something not advisor", func() {
 			It("should return HTTP 202", func() {
 				boiler(http.StatusAccepted,
+					&FilePart{
+						Name:        "file",
+						Content:     "testing",
+						ContentType: "application/vnd.redhat.openshift.test",
+					},
+				)
+			})
+
+			It("should return Content-Type application/json on 202", func() {
+				boilerWithContentType(http.StatusAccepted, "application/json",
 					&FilePart{
 						Name:        "file",
 						Content:     "testing",

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -151,21 +151,15 @@ var _ = Describe("Upload", func() {
 		goodAnemicJsonBody = `{"request_id":"e6b06142958942139a5e1e2f513c448b","upload":{"org_id":"12345"}}`
 	)
 
-	var boiler = func(code int, parts ...*FilePart) {
+	var boiler = func(code int, expectedContentType string, parts ...*FilePart) {
 		req, err := makeMultipartRequest("/api/ingress/v1/upload", parts...)
 		Expect(err).To(BeNil())
 		handler.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(code))
 		Expect(rr.Body).ToNot(BeNil())
-	}
-
-	var boilerWithContentType = func(code int, expectedContentType string, parts ...*FilePart) {
-		req, err := makeMultipartRequest("/api/ingress/v1/upload", parts...)
-		Expect(err).To(BeNil())
-		handler.ServeHTTP(rr, req)
-		Expect(rr.Code).To(Equal(code))
-		Expect(rr.Body).ToNot(BeNil())
-		Expect(rr.Header().Get("Content-Type")).To(Equal(expectedContentType))
+		if expectedContentType != "" {
+			Expect(rr.Header().Get("Content-Type")).To(Equal(expectedContentType))
+		}
 	}
 
 	BeforeEach(func() {
@@ -234,15 +228,8 @@ var _ = Describe("Upload", func() {
 
 	Describe("Posting a file to /upload", func() {
 		Context("with a valid advisor Content-Type and no metadata", func() {
-			It("should return HTTP 201", func() {
-				boiler(http.StatusCreated, &FilePart{
-					Name:        "file",
-					Content:     "testing",
-					ContentType: "application/vnd.redhat.advisor.test"})
-			})
-
-			It("should return Content-Type application/json on 201", func() {
-				boilerWithContentType(http.StatusCreated, "application/json", &FilePart{
+			It("should return HTTP 201 with Content-Type application/json", func() {
+				boiler(http.StatusCreated, "application/json", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.advisor.test"})
@@ -250,18 +237,8 @@ var _ = Describe("Upload", func() {
 		})
 
 		Context("with no metadata from something not advisor", func() {
-			It("should return HTTP 202", func() {
-				boiler(http.StatusAccepted,
-					&FilePart{
-						Name:        "file",
-						Content:     "testing",
-						ContentType: "application/vnd.redhat.openshift.test",
-					},
-				)
-			})
-
-			It("should return Content-Type application/json on 202", func() {
-				boilerWithContentType(http.StatusAccepted, "application/json",
+			It("should return HTTP 202 with Content-Type application/json", func() {
+				boiler(http.StatusAccepted, "application/json",
 					&FilePart{
 						Name:        "file",
 						Content:     "testing",
@@ -273,7 +250,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with a metadata part", func() {
 			It("should return HTTP 202", func() {
-				boiler(http.StatusAccepted,
+				boiler(http.StatusAccepted, "application/json",
 					&FilePart{
 						Name:        "file",
 						Content:     "testing",
@@ -296,7 +273,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with a metadata part containing a queue key", func() {
 			It("should return HTTP 202", func() {
-				boiler(http.StatusAccepted,
+				boiler(http.StatusAccepted, "application/json",
 					&FilePart{
 						Name:        "file",
 						Content:     "testing",
@@ -319,7 +296,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with an invalid metadata part", func() {
 			It("will still return HTTP 202", func() {
-				boiler(http.StatusAccepted,
+				boiler(http.StatusAccepted, "application/json",
 					&FilePart{
 						Name:        "file",
 						Content:     "testing",
@@ -342,7 +319,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with an invalid Content-Type", func() {
 			It("should return HTTP 415", func() {
-				boiler(http.StatusUnsupportedMediaType, &FilePart{
+				boiler(http.StatusUnsupportedMediaType, "", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/invalid",
@@ -352,7 +329,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with a valid file part", func() {
 			It("should return a 202", func() {
-				boiler(http.StatusAccepted, &FilePart{
+				boiler(http.StatusAccepted, "application/json", &FilePart{
 					Name:        "upload",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test",
@@ -362,7 +339,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with an incorrect part name", func() {
 			It("should return HTTP 400", func() {
-				boiler(http.StatusBadRequest, &FilePart{
+				boiler(http.StatusBadRequest, "", &FilePart{
 					Name:        "invalid",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test",
@@ -372,7 +349,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with a valid Content-Type and no metadata", func() {
 			It("should invoke the stager", func() {
-				boiler(http.StatusAccepted, &FilePart{
+				boiler(http.StatusAccepted, "application/json", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test"})
@@ -382,7 +359,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with a valid Content-Type and no metadata", func() {
 			It("should parse to service and category", func() {
-				boiler(http.StatusAccepted, &FilePart{
+				boiler(http.StatusAccepted, "application/json", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test"})
@@ -397,7 +374,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with legacy content type and no metadata", func() {
 			It("should validate and be processed", func() {
-				boiler(http.StatusCreated, &FilePart{
+				boiler(http.StatusCreated, "application/json", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/x-gzip; charset=binary",
@@ -407,7 +384,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with alternate legacy content type and no metadata", func() {
 			It("should validate and be processed", func() {
-				boiler(http.StatusCreated, &FilePart{
+				boiler(http.StatusCreated, "application/json", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/gzip",
@@ -417,7 +394,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with new file command legacy type and no metadata", func() {
 			It("should validate and be processed", func() {
-				boiler(http.StatusCreated, &FilePart{
+				boiler(http.StatusCreated, "application/json", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/gzip; charset=binary",
@@ -427,7 +404,7 @@ var _ = Describe("Upload", func() {
 
 		Context("with invalid service name", func() {
 			It("should return 415", func() {
-				boiler(http.StatusUnsupportedMediaType, &FilePart{
+				boiler(http.StatusUnsupportedMediaType, "", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.failed.test"})
@@ -439,7 +416,7 @@ var _ = Describe("Upload", func() {
 				cfg := config.Get()
 				cfg.DefaultMaxSize = 1
 				handler = NewHandler(stager, validator, tracker, *cfg)
-				boiler(http.StatusRequestEntityTooLarge, &FilePart{
+				boiler(http.StatusRequestEntityTooLarge, "", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test",
@@ -455,7 +432,7 @@ var _ = Describe("Upload", func() {
 				cfg.DefaultMaxSize = 1
 				cfg.MaxSizeMap = TypeMap
 				handler = NewHandler(stager, validator, tracker, *cfg)
-				boiler(http.StatusAccepted, &FilePart{
+				boiler(http.StatusAccepted, "application/json", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.qpc.test",
@@ -467,7 +444,7 @@ var _ = Describe("Upload", func() {
 			It("should return 413", func() {
 				stager = &stage.Fake{ShouldError: true}
 				handler = NewHandler(stager, validator, tracker, *config.Get())
-				boiler(http.StatusInternalServerError, &FilePart{
+				boiler(http.StatusInternalServerError, "", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test",
@@ -479,7 +456,7 @@ var _ = Describe("Upload", func() {
 				cfg := config.Get()
 				cfg.DenyListedOrgIDs = []string{"12345"}
 				handler = NewHandler(stager, validator, tracker, *cfg)
-				boiler(http.StatusForbidden, &FilePart{
+				boiler(http.StatusForbidden, "", &FilePart{
 					Name:        "file",
 					Content:     "testing",
 					ContentType: "application/vnd.redhat.unit.test",


### PR DESCRIPTION
Calling `WriteHeader()` flushes the headers and sticks to plain despite a set, this PR sets before that to avoid it.

Closes RHCLOUD-45847