### PR TITLE
[RHCLOUD-44657] Upgrade go-chi/chi from v4 to v5

### DIFF
--- a/cmd/insights-ingress/main.go
+++ b/cmd/insights-ingress/main.go
@@ -22,8 +22,8 @@ import (
 	"github.com/redhatinsights/insights-ingress-go/internal/validators/kafka"
 	"github.com/redhatinsights/insights-ingress-go/internal/version"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/insights-ingress-go
 
-go 1.24.13
+go 1.25.9
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.13
 require (
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/confluentinc/confluent-kafka-go/v2 v2.11.1
-	github.com/go-chi/chi v4.1.2+incompatible
+	github.com/go-chi/chi/v5 v5.2.5
 	github.com/google/uuid v1.6.0
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/minio/minio-go/v6 v6.0.57

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fvbommel/sortorder v1.0.2 h1:mV4o8B2hKboCdkJm+a7uX/SIpZob4JzUpc5GGnM45eo=
 github.com/fvbommel/sortorder v1.0.2/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
-github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
-github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/insights-ingress-go/internal/config"
 	"github.com/redhatinsights/insights-ingress-go/internal/stage/filebased"
 )

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -1,7 +1,7 @@
 package download_test
 
 import (
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 	"net/http"
 	"net/http/httptest"
 	"os"

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/insights-ingress-go/internal/config"
 	l "github.com/redhatinsights/insights-ingress-go/internal/logger"
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"

--- a/internal/track/track_test.go
+++ b/internal/track/track_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
## Summary
- Upgrades `github.com/go-chi/chi` v4 → `github.com/go-chi/chi/v5` to resolve deprecation warning in pipeline builds
- Updates all import paths across `main.go`, `download`, and `track` packages

## Note on aws-sdk-go
`github.com/aws/aws-sdk-go` v1 cannot be upgraded to v2 yet because `platform-go-middlewares/v2` cloudwatch logging package still depends on aws-sdk-go v1 types (`*aws.Config`, `credentials`). This requires an upstream change in platform-go-middlewares first.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` all tests pass