### PR TITLE
Add AI-assisted development documentation system

### DIFF
--- a/.claude/rules/api-contracts.md
+++ b/.claude/rules/api-contracts.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/api/**"
+  - "cmd/insights-ingress/main.go"
+---
+
+@docs/api-contracts-guidelines.md

--- a/.claude/rules/async-and-messaging.md
+++ b/.claude/rules/async-and-messaging.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/queue/**"
+  - "internal/announcers/**"
+---
+
+@docs/async-and-messaging-guidelines.md

--- a/.claude/rules/code-organization.md
+++ b/.claude/rules/code-organization.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "cmd/**"
+  - "internal/**"
+---
+
+@docs/code-organization-guidelines.md

--- a/.claude/rules/configuration.md
+++ b/.claude/rules/configuration.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/config/**"
+  - "deploy/clowdapp.yaml"
+---
+
+@docs/configuration-guidelines.md

--- a/.claude/rules/content-type-routing.md
+++ b/.claude/rules/content-type-routing.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "internal/upload/validation.go"
+---
+
+@docs/content-type-routing-guidelines.md

--- a/.claude/rules/data-validation.md
+++ b/.claude/rules/data-validation.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/upload/**"
+  - "internal/validators/**"
+---
+
+@docs/data-validation-guidelines.md

--- a/.claude/rules/dependency-management.md
+++ b/.claude/rules/dependency-management.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "go.mod"
+  - "go.sum"
+  - "renovate.json"
+---
+
+@docs/dependency-management-guidelines.md

--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - "deploy/**"
+  - ".tekton/**"
+  - ".github/workflows/**"
+  - "Dockerfile*"
+---
+
+@docs/deployment-guidelines.md

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/upload/upload.go"
+  - "internal/track/track.go"
+---
+
+@docs/error-handling-guidelines.md

--- a/.claude/rules/integration.md
+++ b/.claude/rules/integration.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/stage/**"
+  - "internal/validators/kafka/**"
+---
+
+@docs/integration-guidelines.md

--- a/.claude/rules/logging-and-observability.md
+++ b/.claude/rules/logging-and-observability.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "internal/logger/**"
+  - "internal/upload/metrics.go"
+  - "internal/validators/kafka/metrics.go"
+---
+
+@docs/logging-and-observability-guidelines.md

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/queue/**"
+  - "internal/upload/upload.go"
+---
+
+@docs/performance-guidelines.md

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/upload/upload.go"
+  - "internal/track/**"
+---
+
+@docs/security-guidelines.md

--- a/.claude/rules/storage-patterns.md
+++ b/.claude/rules/storage-patterns.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/stage/**"
+  - "internal/download/**"
+---
+
+@docs/storage-patterns-guidelines.md

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "**/*_test.go"
+  - "**/*_suite_test.go"
+---
+
+@docs/testing-guidelines.md

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# See https://docs.coderabbit.ai/reference/configuration for all fields and default values
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - "docs/*-guidelines.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+## Project Overview
+
+**insights-ingress-go** is a Go service in the Red Hat cloud.redhat.com platform that receives file uploads from clients, stages them to object storage (S3-compatible or filesystem), and announces them to downstream services via Kafka. It runs inside OpenShift behind a 3Scale authentication gateway.
+
+- **Language**: Go (1.25+)
+- **Module**: `github.com/redhatinsights/insights-ingress-go`
+- **Entry point**: `cmd/insights-ingress/main.go`
+- **All business logic**: `internal/` (no exported library packages)
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Build | `make build` |
+| Test (all) | `make test` |
+| Test (CI mode) | `ACG_CONFIG="$(pwd)/cdappconfig.json" go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...` |
+| Run locally (S3/MinIO) | `make start-api-dependencies && make run-api` |
+| Run locally (filesystem) | `make start-filebased-api-dependencies && make run-filebased-api` |
+| Test upload | `make run-upload-test` |
+| Docker build | `docker build -f Dockerfile -t ingress:latest .` |
+
+**macOS note**: On macOS, builds and tests require `-tags dynamic` (already set in the Makefile). You also need `brew install pkg-config librdkafka`.
+
+## Cross-Cutting Conventions
+
+### Configuration
+
+- All config goes through `internal/config/config.go` using Viper with env prefix `INGRESS_`.
+- Clowder integration is gated behind `clowder.IsClowderEnabled()`.
+- See [docs/configuration-guidelines.md](docs/configuration-guidelines.md) for details.
+
+### Logging
+
+- Use the global `l.Log` logger (import aliased as `l`). Never use `fmt.Println` or standard `log`.
+- Always use `logrus.Fields` for structured logging. Include `request_id` on every request-scoped log.
+- See [docs/logging-and-observability-guidelines.md](docs/logging-and-observability-guidelines.md) for details.
+
+### Error Handling
+
+- HTTP handlers write status codes and return directly; they do not return errors.
+- Use `logrus.Fields{"error": err}` for attaching errors. Use `Fatal` only in `main.go` for startup failures.
+- See [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) for details.
+
+### Testing
+
+- Framework: Ginkgo v1 + Gomega (dot-imported). Do not use Ginkgo v2.
+- Each test package has a `*_suite_test.go` bootstrap file that calls `l.InitLogger(config.Get())`.
+- Use in-repo fakes (`stage.Fake`, `validators.Fake`, `announcers.Fake`) instead of mocking.
+- Tests must run sequentially: `go test -p 1 -v ./...`
+- See [docs/testing-guidelines.md](docs/testing-guidelines.md) for details.
+
+### Interfaces and Dependency Injection
+
+- Define interfaces in `types.go` within each domain package.
+- Implementations live in sub-packages (e.g., `stage/s3compat/`, `stage/filebased/`, `validators/kafka/`).
+- Fakes live in `fake.go` alongside the interface.
+- Handlers are constructed via `NewHandler(...)` functions that accept interface dependencies.
+
+### Metrics
+
+- Use `prometheus/client_golang/prometheus/promauto` for auto-registration.
+- Prefix all metric names with `ingress_`.
+- Declare metrics in dedicated `metrics.go` files.
+- Normalize user-agent strings via `NormalizeUserAgent()` before using as labels.
+
+## Key Design Decisions
+
+1. **Single Kafka announce topic**: All upload types go to `platform.upload.announce` with a `service` Kafka header for consumer filtering.
+2. **Content-type routing**: Service name extracted from `application/vnd.redhat.<service>.<category>` MIME type pattern.
+3. **Stager abstraction**: Storage backend is pluggable via the `stage.Stager` interface (S3 or filesystem), selected at runtime via `StagerImplementation` config.
+4. **Produce-only Kafka architecture**: Two independent Kafka producers run in dedicated goroutines — one for validation announcements (`platform.upload.announce`), one for status tracking (`platform.payload-status`). The service does not consume messages.
+5. **Retry by requeue**: Failed Kafka publishes are re-enqueued to the channel with no backoff.
+
+## CI/CD
+
+- **GitHub Actions** (`pr.yml`): Runs `go test ./...` and validates `internal/api/openapi.json` on PRs.
+- **Tekton/Konflux** (`.tekton/`): Hermetic builds with Go module prefetch on `master` branch.
+- **App-SRE** (`pr_check.sh`, `build_deploy.sh`): Bonfire-based ephemeral environment testing and quay.io image publishing.
+- **Renovate** (`renovate.json`): Automated Go dependency updates.
+- **Dependabot** (`.github/dependabot.yml`): Docker base image updates on `security-compliance` branch only.
+
+## Detailed Guidelines Index
+
+Each file below contains specific, enforceable rules for its domain. Read the relevant file before making changes in that area.
+
+| Domain | File |
+|--------|------|
+| API contracts and endpoints | [docs/api-contracts-guidelines.md](docs/api-contracts-guidelines.md) |
+| Kafka messaging and producers | [docs/async-and-messaging-guidelines.md](docs/async-and-messaging-guidelines.md) |
+| Package structure and patterns | [docs/code-organization-guidelines.md](docs/code-organization-guidelines.md) |
+| Viper/Clowder configuration | [docs/configuration-guidelines.md](docs/configuration-guidelines.md) |
+| Content-type parsing and routing | [docs/content-type-routing-guidelines.md](docs/content-type-routing-guidelines.md) |
+| Input validation and metadata | [docs/data-validation-guidelines.md](docs/data-validation-guidelines.md) |
+| Go modules and dependencies | [docs/dependency-management-guidelines.md](docs/dependency-management-guidelines.md) |
+| Dockerfiles, ClowdApp, CI/CD | [docs/deployment-guidelines.md](docs/deployment-guidelines.md) |
+| Error codes and error propagation | [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) |
+| Storage, Kafka, and platform integration | [docs/integration-guidelines.md](docs/integration-guidelines.md) |
+| Logging, metrics, and tracing | [docs/logging-and-observability-guidelines.md](docs/logging-and-observability-guidelines.md) |
+| Memory limits, concurrency, profiling | [docs/performance-guidelines.md](docs/performance-guidelines.md) |
+| Auth, TLS, deny lists, input sanitization | [docs/security-guidelines.md](docs/security-guidelines.md) |
+| S3 and filesystem staging patterns | [docs/storage-patterns-guidelines.md](docs/storage-patterns-guidelines.md) |
+| Ginkgo/Gomega testing conventions | [docs/testing-guidelines.md](docs/testing-guidelines.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+@AGENTS.md
+
+## Build & Test Commands
+
+- **Build**: `make build`
+- **Test**: `make test` (runs `go test -p 1 -v ./...` with correct platform tags)
+- **macOS prerequisite**: `brew install pkg-config librdkafka` (builds use `-tags dynamic` automatically)
+
+## CI Checks to Match
+
+- PR workflow runs `go test ./...` and validates `internal/api/openapi.json` with `openapi-spec-validator`
+- If you change the OpenAPI spec, ensure it remains valid JSON and passes validation
+
+## Key Gotchas
+
+- Tests require sequential execution (`-p 1`); parallel packages will fail
+- The `ACG_CONFIG` env var must point to `cdappconfig.json` for CI-mode tests
+- `development/.env` contains local-only MinIO credentials committed intentionally; do not add real secrets
+- The binary output (`insights-ingress-go`) is gitignored; do not commit it

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Insights Ingress
 
-Ingress is designed to receive payloads from clients and distribute them via a
-Kafka message queue to other platform services.
+Ingress is a Go service that receives file upload payloads from clients and distributes them via a Kafka message queue to other platform services. It stages uploads to S3-compatible object storage (or local filesystem) and announces them to downstream consumers.
 
 ## Details
 
@@ -14,6 +13,41 @@ to a Kafka message queue in order to notify services of new and available upload
 for processing.
 
 The service runs inside Openshift Dedicated.
+
+## Documentation
+
+- **[AGENTS.md](AGENTS.md)** -- Conventions, architecture decisions, and cross-cutting guidelines for AI agents and contributors
+- **[docs/](docs/)** -- Detailed domain-specific guidelines (API contracts, testing, configuration, security, and more)
+- **[development/README.md](development/README.md)** -- Local development environment setup with Docker/Podman Compose
+
+## Project Structure
+
+```
+insights-ingress-go/
+├── cmd/
+│   ├── insights-ingress/       # Application entry point (main.go)
+│   └── example-ingress-client/ # Example upload client
+├── internal/
+│   ├── api/                    # HTTP handlers and OpenAPI spec
+│   ├── config/                 # Viper-based configuration with Clowder support
+│   ├── announcers/             # Kafka announce producer interface and fakes
+│   ├── validators/             # Upload validation interface
+│   │   └── kafka/              # Kafka-based validator implementation
+│   ├── stage/                  # Storage staging interface
+│   │   ├── s3compat/           # S3/MinIO storage backend
+│   │   └── filebased/          # Local filesystem storage backend
+│   ├── upload/                 # Upload processing pipeline
+│   ├── queue/                  # Kafka producer goroutines
+│   ├── track/                  # Payload status tracking
+│   ├── download/               # Download handler
+│   ├── logger/                 # Structured logging setup (logrus)
+│   └── version/                # Build version info
+├── development/                # Docker Compose and local dev configs
+├── deploy/                     # ClowdApp deployment manifests
+├── docs/                       # Detailed domain-specific guidelines
+├── Dockerfile                  # Production container build
+└── Makefile                    # Build, test, and local run targets
+```
 
 ## How It Works
 
@@ -117,7 +151,7 @@ cloud.redhat.com, the customer should engage with support.
 
 #### Prerequisites
 
-Golang >= 1.21
+Go >= 1.25
 
 **macOS additional dependencies (for running with `-tags dynamic`):**
 
@@ -125,7 +159,19 @@ Golang >= 1.21
 brew install pkg-config librdkafka
 ```
 
-These are required for building with the `dynamic` tag, which links against the system librdkafka library for Kafka support.
+These are required for building with the `dynamic` tag, which links against the system librdkafka library for Kafka support. The Makefile automatically applies `-tags dynamic` on macOS.
+
+#### Tech Stack
+
+| Component | Library |
+|-----------|---------|
+| HTTP router | [chi/v5](https://github.com/go-chi/chi) |
+| Kafka | [confluent-kafka-go/v2](https://github.com/confluentinc/confluent-kafka-go) |
+| S3 storage | [minio-go/v6](https://github.com/minio/minio-go) / [aws-sdk-go](https://github.com/aws/aws-sdk-go) |
+| Configuration | [Viper](https://github.com/spf13/viper) + [Clowder app-common-go](https://github.com/redhatinsights/app-common-go) |
+| Metrics | [Prometheus client_golang](https://github.com/prometheus/client_golang) |
+| Logging | [Logrus](https://github.com/sirupsen/logrus) |
+| Testing | [Ginkgo v1](https://github.com/onsi/ginkgo) + [Gomega](https://github.com/onsi/gomega) |
 
 #### Launching the Service
 
@@ -149,7 +195,17 @@ You can also build ingress using Docker/Podman with the provided Dockerfile.
 
 ### Local Development
 
-More information on local development can be found [here](./development/README.md)
+To run the full stack locally with dependencies (Kafka, MinIO/filesystem), see [development/README.md](./development/README.md).
+
+**Quick start with S3/MinIO backend:**
+
+    $> make start-api-dependencies
+    $> make run-api
+
+**Quick start with filesystem backend:**
+
+    $> make start-filebased-api-dependencies
+    $> make run-filebased-api
 
 #### Uploading a File
 
@@ -174,3 +230,5 @@ This decodes to:
 Use `go test` to test the application
 
     $> make test
+
+For detailed testing conventions (Ginkgo/Gomega patterns, fakes, CI configuration), see [AGENTS.md](AGENTS.md) and [docs/testing-guidelines.md](docs/testing-guidelines.md).

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -1,0 +1,111 @@
+# API Contracts
+
+## Routing and URL Structure
+
+- Mount all API routes under two base paths via `chi.Mount`: `/api/ingress/v1` and `/r/insights/platform/ingress/v1`. Both serve the same subrouter.
+- Use `go-chi/chi/v5` for all routing. Do not introduce alternative routers.
+- Define handlers as `http.HandlerFunc` values returned by constructor functions (e.g., `upload.NewHandler`, `track.NewHandler`, `download.NewHandler`).
+- Extract path parameters with `chi.URLParam(r, "paramName")`, not from `mux.Vars` or manual parsing.
+
+## Endpoints
+
+The service exposes exactly these routes on the API subrouter:
+
+| Method | Path                  | Handler                       | Auth Required |
+|--------|-----------------------|-------------------------------|---------------|
+| GET    | `/`                   | `lubDub` (health check)       | Conditional   |
+| POST   | `/upload`             | `upload.NewHandler`           | Conditional   |
+| GET    | `/track/{requestID}`  | `track.NewHandler`            | Required*     |
+| GET    | `/version`            | `version.GetVersion`          | No            |
+| GET    | `/openapi.json`       | `apiSpec` (serves embedded spec) | No         |
+
+*The `/track/{requestID}` route is only registered when `cfg.Auth` is true. When auth is disabled, this endpoint does not exist.
+
+A separate `/download/{requestID}` route is mounted at the root router level only when `StagerImplementation == "filebased"`.
+
+Metrics are served on a separate port via `/metrics` (Prometheus `promhttp.Handler`).
+
+## OpenAPI Specification
+
+- The canonical API spec lives at `internal/api/openapi.json` as an OpenAPI 3.0.0 document.
+- It is embedded into the binary at compile time via `//go:embed openapi.json` in `internal/api/api.go` and exposed as `api.ApiSpec`.
+- Keep `openapi.json` in sync with any endpoint or response schema changes. The spec defines three paths: `/upload`, `/version`, and `/track/{request_id}`.
+
+## Content-Type Handling
+
+- Uploads use `multipart/form-data`. The file part is read from either the `file` or `upload` form field (tried in that order via `GetFile` in `internal/upload/upload.go`).
+- The service descriptor (service name + category) is extracted from the inner Content-Type header of the file part, not the outer request Content-Type.
+- Custom content types follow the pattern: `application/vnd.redhat.<service>.<category>...` parsed by the regex in `internal/upload/validation.go`:
+  ```
+  application/vnd\.redhat\.([a-z0-9-]+)\.([a-z0-9-]+).*
+  ```
+- Legacy gzip types (`application/x-gzip; charset=binary`, `application/gzip`, `application/gzip; charset=binary`) map to service `advisor` with category `upload`.
+- Unrecognized content types return HTTP 415.
+
+## Request Headers
+
+- `x-rh-insights-request-id`: Extracted by `request_id.ConfiguredRequestID` middleware. Used as the payload's unique key throughout the pipeline.
+- `x-rh-identity`: Base64-encoded identity JSON. Decoded by `platform-go-middlewares/v2/identity`. Read directly from the header for `B64Identity` field on the validation request.
+- `User-Agent`: Logged and used for Prometheus metric labels. Normalize via `upload.NormalizeUserAgent` before using as a label value.
+
+## Authentication Middleware
+
+- When `cfg.Auth` is true, apply `identity.EnforceIdentityWithLogger` middleware to protected routes.
+- Pass a custom error logging function of signature `func(ctx context.Context, rawId, msg string)` to `EnforceIdentityWithLogger`.
+- The `/version` and `/openapi.json` endpoints do not require identity enforcement regardless of auth configuration.
+- The `/track/{requestID}` endpoint is only registered when `cfg.Auth` is true.
+
+## Response Conventions
+
+- Responses from `/upload` use `application/json` Content-Type.
+- Successful upload with `advisor` service and no metadata returns HTTP 201. Other successful uploads return HTTP 202.
+- Test connection requests (form value `test=test` or JSON body `{"test":"test"}`) return HTTP 200.
+- The upload JSON response body uses the `responseBody` struct shape: `{"request_id": "...", "upload": {"account_number": "...", "org_id": "..."}}`.
+- The `/version` endpoint returns `{"version": "...", "commit": "..."}` with HTTP 200.
+- The `/track/{requestID}` endpoint returns `MinimalStatus` by default; full `TrackerResponse` when query param `verbosity >= 2`.
+
+## HTTP Status Codes
+
+| Code | Meaning in this service |
+|------|------------------------|
+| 200  | Test connection / health check / track response |
+| 201  | Advisor upload without metadata accepted |
+| 202  | Payload accepted for processing |
+| 400  | Missing file/upload part, or invalid request ID format |
+| 403  | Org ID is deny-listed, or track authorization failure |
+| 404  | Request ID not found in payload tracker |
+| 413  | File exceeds `DefaultMaxSize` or per-service `MaxSizeMap` limit |
+| 415  | Content type unrecognized or service not in valid upload types |
+| 500  | Staging failure or internal marshaling error |
+
+## Middleware Ordering
+
+Apply middleware to the upload route in this order (set via `sub.With(...)`):
+1. `upload.ResponseMetricsMiddleware` (wraps `ResponseWriter` for status code tracking)
+2. `identity.EnforceIdentityWithLogger` (when auth is enabled)
+3. `middleware.Logger` (chi request logging)
+
+## Metadata Handling
+
+- Metadata is optional. It is read from either a `metadata` form file part or a `metadata` form value.
+- When present, it is unmarshaled into `validators.Metadata`. The `Reporter` field is hard-coded to `"ingress"` and `StaleTimestamp` is set to 30 days from now.
+- Failed metadata parsing logs a debug message but does not fail the request.
+
+## Verification
+
+```bash
+# Confirm the OpenAPI spec is valid JSON and has expected paths
+python3 -c "import json; d=json.load(open('internal/api/openapi.json')); assert '/upload' in d['paths'] and '/version' in d['paths'] and '/track/{request_id}' in d['paths']"
+
+# Confirm both mount paths exist
+grep -n 'r.Mount' cmd/insights-ingress/main.go
+
+# Confirm upload form field names
+grep -n 'FormFile' internal/upload/upload.go
+
+# Confirm response status codes in upload handler
+grep -n 'WriteHeader' internal/upload/upload.go
+
+# Run the test suite
+go test -p 1 -v ./...
+```

--- a/docs/async-and-messaging-guidelines.md
+++ b/docs/async-and-messaging-guidelines.md
@@ -1,0 +1,93 @@
+# Async and Messaging
+
+## Architecture Overview
+
+This service is a produce-only Kafka application. It does not consume messages. Two independent Kafka producers exist, each backed by a dedicated goroutine running `queue.Producer`:
+
+1. **Validation announcer** -- publishes upload metadata to `platform.upload.announce` so downstream services can validate payloads.
+2. **Status tracker** -- publishes status events to `platform.payload-status` for the payload-tracker service.
+
+## Kafka Client Library
+
+- Use `github.com/confluentinc/confluent-kafka-go/v2/kafka` (the confluent-kafka-go v2 module). Do not introduce alternative Kafka libraries.
+
+## Producer Pattern
+
+- Kafka producing flows through `internal/queue/queue.go` via the `Producer` function. Do not create additional producer implementations or call `kafka.NewProducer` outside this package.
+- `Producer` reads from a `chan validators.ValidationMessage` and spawns a goroutine per message. Each goroutine creates its own `delivery_chan` to confirm delivery synchronously before returning.
+- On delivery failure, `Producer` re-enqueues the message back onto the input channel (`in <- v`). Preserve this retry-by-requeue behavior when modifying producer logic.
+- `kafka.PartitionAny` is used for all messages. Do not assign explicit partitions.
+- When `Metadata.QueueKey` is present in the upload request, set `ValidationMessage.Key` to that value so related messages land on the same partition. See `internal/validators/kafka/kafka.go`.
+
+## Channel Buffer Sizes
+
+- The validation producer channel in `internal/validators/kafka/kafka.go` is buffered at 100: `make(chan validators.ValidationMessage, 100)`.
+- The status announcer channel in `internal/announcers/kafka.go` is buffered at 1000: `make(chan validators.ValidationMessage, 1000)`.
+- Preserve these buffer sizes or justify changes with load analysis.
+
+## Topic Configuration
+
+- Topic names are configured via `internal/config/config.go` in the `KafkaCfg` struct:
+  - `KafkaAnnounceTopic` (default: `platform.upload.announce`)
+  - `KafkaTrackerTopic` (default: `platform.payload-status`)
+- When Clowder is enabled, topic names are resolved through `clowder.KafkaTopics[requestedName].Name`. Use `config.GetTopic()` for any topic name resolution at runtime.
+- Do not hardcode topic name strings outside of config defaults.
+
+## Message Schemas
+
+- **Validation messages** (`validators.Request`): JSON-serialized struct containing `account`, `org_id`, `request_id`, `service`, `category`, `url`, `b64_identity`, `size`, `content_type`, `timestamp`, and nested `metadata`. Defined in `internal/validators/types.go`.
+- **Status messages** (`announcers.Status`): JSON-serialized struct containing `service` (hardcoded to `"ingress"`), `account`, `org_id`, `request_id`, `status`, `status_msg`, `date`. Defined in `internal/announcers/kafka.go`.
+- Validation messages carry a `Headers` map; the `service` header is set to `vr.Service` to allow topic-level filtering by downstream consumers.
+
+## The Announcer Interface
+
+- `internal/announcers/kafka.go` defines the `Announcer` interface with `Status(*Status)` and `Stop()` methods.
+- Use `announcers.NewStatusAnnouncer(*queue.ProducerConfig)` to create the Kafka-backed implementation.
+- Call `Stop()` to close the input channel and shut down the producer.
+
+## The Validator Interface
+
+- `internal/validators/types.go` defines the `Validator` interface with `Validate(*Request)` and `ValidateService(*ServiceDescriptor) error`.
+- `internal/validators/kafka/kafka.go` implements this interface. `New()` accepts a `*Config` and a variadic list of valid service names.
+- `ValidateService` checks against a `map[string]bool` built from `ValidUploadTypes` config. This check happens before any Kafka message is produced.
+
+## Kafka Security Configuration
+
+- SSL/SASL settings flow from `config.KafkaSSLCfg` through `queue.ProducerConfig` to `kafka.ConfigMap`:
+  - Set `ssl.ca.location` only when `CA` is non-empty.
+  - Set `security.protocol`, `sasl.mechanism`, `sasl.username`, `sasl.password` only when `SASLMechanism` is non-empty.
+- In Clowder environments, credentials come from `broker.Sasl` and CA from `broker.Cacert`.
+
+## Testing Fakes
+
+- Use `validators.Fake` (in `internal/validators/fake.go`) when testing upload handlers without Kafka.
+- Use `announcers.Fake` (in `internal/announcers/fake.go`) when testing without the status announcer.
+- Prefer these fakes over mocking the Kafka client directly.
+
+## Message Flow Summary
+
+1. HTTP upload arrives at `internal/upload/upload.go` handler.
+2. Handler sends `"received"` status via `tracker.Status()` (produces to `platform.payload-status`).
+3. Payload is staged to S3/MinIO/filesystem.
+4. Handler sends `"success"` status via `tracker.Status()`.
+5. Handler calls `validator.Validate(vr)` which produces the `validators.Request` JSON to `platform.upload.announce` with the `service` header.
+6. HTTP response is returned (202 Accepted, or 201 Created for advisor without metadata).
+
+## Verification
+
+```bash
+# Confirm only confluent-kafka-go is used as Kafka library
+grep -r "kafka" go.mod | grep -v "confluent-kafka-go"
+
+# Confirm Kafka producing goes through queue.Producer
+grep -rn "kafka.NewProducer" internal/ --include="*.go"
+
+# Confirm channel buffer sizes
+grep -n "make(chan validators.ValidationMessage" internal/ -r --include="*.go"
+
+# Confirm topic names are not hardcoded outside config
+grep -rn '"platform\.' internal/ --include="*.go" | grep -v config.go | grep -v _test.go
+
+# Run tests
+go test ./internal/validators/kafka/... ./internal/upload/... ./internal/announcers/...
+```

--- a/docs/code-organization-guidelines.md
+++ b/docs/code-organization-guidelines.md
@@ -1,0 +1,71 @@
+# Code Organization
+
+## Package Layout
+
+- Place the service entry point in `cmd/insights-ingress/main.go`; additional CLI tools go under `cmd/<tool-name>/`.
+- Place all business logic under `internal/`; this codebase has no exported library packages.
+- Organize `internal/` by domain concern, one directory per concern: `upload`, `stage`, `validators`, `announcers`, `queue`, `track`, `download`, `config`, `logger`, `api`, `version`.
+
+## Interface-Driven Architecture
+
+- Define interfaces in `types.go` within the domain package (see `internal/stage/types.go` for `Stager`, `internal/validators/types.go` for `Validator`, `internal/announcers/kafka.go` for `Announcer`).
+- Keep data structs that cross package boundaries in the same `types.go` file alongside the interface.
+- Implementations of an interface reside in sub-packages: `internal/stage/s3compat/` and `internal/stage/filebased/` both implement `stage.Stager`; `internal/validators/kafka/` implements `validators.Validator`.
+
+## Fake / Test Doubles
+
+- Place fakes in a file named `fake.go` in the same package as the interface they implement (e.g., `internal/stage/fake.go`, `internal/validators/fake.go`, `internal/announcers/fake.go`).
+- Name the struct `Fake` and include boolean tracking fields (e.g., `StageCalledV`, `StatusCalledV`) with thread-safe accessor methods using `sync.Mutex`.
+- Use `ShouldError bool` on fakes to toggle error paths in tests.
+
+## Handler Construction Pattern
+
+- Construct HTTP handlers with a `NewHandler` function that accepts interface dependencies and returns `http.HandlerFunc`. See `upload.NewHandler`, `track.NewHandler`, `download.NewHandler`.
+- Wire dependencies in `cmd/insights-ingress/main.go` using concrete implementations selected by config (e.g., `getStager` selects between `s3compat` and `filebased`).
+
+## Import Conventions
+
+- Alias `internal/logger` as `l` (e.g., `l "github.com/redhatinsights/insights-ingress-go/internal/logger"`).
+- Alias `prometheus/client_golang/prometheus` as `p` and `prometheus/promauto` as `pa` in metrics files.
+- Use dot-imports (`. "..."`) for Ginkgo (`github.com/onsi/ginkgo`) and Gomega (`github.com/onsi/gomega`) in test files, and for the package under test.
+
+## Metrics
+
+- Define Prometheus metrics as package-level `var` blocks using `promauto` (`pa.NewCounterVec`, `pa.NewHistogramVec`, `pa.NewGauge`).
+- Place metrics declarations in a separate `metrics.go` file within the package (see `internal/upload/metrics.go`, `internal/validators/kafka/metrics.go`).
+- Prefix metric names with `ingress_` (e.g., `ingress_requests`, `ingress_kafka_produced`, `ingress_stage_seconds`).
+
+## Routing
+
+- Use `github.com/go-chi/chi/v5` for HTTP routing. Mount the API sub-router at both `/api/ingress/v1` and `/r/insights/platform/ingress/v1`.
+- Run a separate metrics HTTP server on `MetricsPort` with a dedicated `chi.NewRouter`.
+- Apply `request_id.ConfiguredRequestID("x-rh-insights-request-id")` middleware for request ID propagation.
+- Use `identity.EnforceIdentityWithLogger` from `platform-go-middlewares/v2` when `cfg.Auth` is true.
+
+## Embedded Assets
+
+- Embed the OpenAPI spec using `//go:embed openapi.json` in `internal/api/api.go` as `var ApiSpec []byte`.
+
+## Build
+
+- Build command: `go build -o insights-ingress-go cmd/insights-ingress/main.go`.
+- On macOS, use `-tags dynamic` for both build and test (required by confluent-kafka-go CGo bindings).
+
+## Verification
+
+```bash
+# Confirm all packages compile
+go build ./...
+
+# Run all tests (use -tags dynamic on macOS)
+go test -p 1 -v ./...
+
+# Verify interface satisfaction
+grep -rn 'type Fake struct' internal/
+
+# Check that metrics follow naming convention
+grep -rn 'Name:.*"ingress_' internal/
+
+# Confirm no exported packages outside cmd/ and internal/
+ls -d */ | grep -v -E '^(cmd|internal|development|deploy|docs|dashboards|licenses|\.)'
+```

--- a/docs/configuration-guidelines.md
+++ b/docs/configuration-guidelines.md
@@ -1,0 +1,88 @@
+# Configuration
+
+## Configuration Architecture
+
+- Runtime configuration is centralized in `internal/config/config.go` via the `Get()` function, which returns a pointer to `IngressConfig`.
+- Configuration uses two Viper instances: `options` (with env prefix `INGRESS`) for application config and `kubenv` (no prefix) for Kubernetes/OpenShift env vars like `OPENSHIFT_BUILD_COMMIT`.
+- When Clowder is enabled (`clowder.IsClowderEnabled()`), Clowder's `LoadedConfig` overrides Viper defaults for Kafka, storage, ports, TLS, and CloudWatch settings.
+- `config.Get()` creates a new Viper instance and re-reads all config on every call. Callers in `main.go` call it once and pass the resulting `IngressConfig` to downstream components.
+
+## Adding New Configuration Values
+
+- Register every new config key with `options.SetDefault()` in `Get()` before the Clowder block.
+- Add a corresponding field to `IngressConfig` or one of its nested structs (`KafkaCfg`, `StorageCfg`, `LoggingCfg`, `KafkaSSLCfg`).
+- Read the value from `options` using typed getters (`GetString`, `GetBool`, `GetInt`, `GetInt64`, `GetStringSlice`, `GetStringMapString`).
+- If the value should be overridden by Clowder, add a second `options.SetDefault()` or `options.Set()` call inside the `if clowder.IsClowderEnabled()` block.
+
+## Environment Variable Naming
+
+- Viper env prefix is `INGRESS` (set via `options.SetEnvPrefix("INGRESS")`), so env vars follow `INGRESS_<KEY>`.
+- Viper key names use mixed case (e.g., `KafkaBrokers`, `MinioEndpoint`, `Valid_Upload_Types`). Viper maps these case-insensitively to env vars.
+- Keys containing underscores (e.g., `Valid_Upload_Types`, `Deny_Listed_OrgIDs`) are used as-is; do not normalize to camelCase.
+
+## Clowder Integration
+
+- Gate all Clowder-specific logic behind `clowder.IsClowderEnabled()`.
+- Use `clowder.LoadedConfig` to access Clowder-provided values.
+- Look up Kafka topic names via `clowder.KafkaTopics["<requested-topic-name>"].Name`.
+- Use the `GetTopic()` helper in `internal/config/config.go` for runtime topic resolution.
+- Access the storage bucket via `clowder.ObjectBuckets[sb]` where `sb` comes from `INGRESS_STAGEBUCKET`.
+- Use `options.Set()` (not `SetDefault`) for Clowder values that should unconditionally override env vars.
+- Use `options.SetDefault()` for Clowder values where env var overrides should still be possible.
+
+## Clowder Config File
+
+- `cdappconfig.json` at the repo root is a local Clowder config fixture for development/testing.
+- The ClowdApp deployment manifest is at `deploy/clowdapp.yaml` -- declares Kafka topics, object store buckets, and all `INGRESS_*` env vars.
+
+## Stager Implementation Selection
+
+- `StagerImplementation` controls storage backend: `"s3"` (default) or `"filebased"`.
+- Register new stagers by adding a corresponding branch in `getStager()` in `cmd/insights-ingress/main.go`. `GetStagerImplementation()` in `internal/config/config.go` normalizes the stager name but is not where new stagers are registered.
+
+## Per-Service Max Size Overrides
+
+- `DefaultMaxSize` sets the global upload size limit (default: 100 MB).
+- `MaxSizeMap` is a JSON string-map providing per-service overrides (e.g., `{"qpc": "157286400"}`). Values are string representations of byte counts.
+- Upload size checking in `internal/upload/upload.go` looks up `cfg.MaxSizeMap[vr.Service]` first, then falls back to `cfg.DefaultMaxSize`.
+
+## Valid Upload Types
+
+- `Valid_Upload_Types` is a comma-separated string split into a slice at startup.
+- Controls which content-type service names are accepted. Unrecognized service names receive HTTP 415.
+- Update `INGRESS_VALID_UPLOAD_TYPES` in `deploy/clowdapp.yaml` when deploying.
+
+## Deny-Listed Org IDs
+
+- `Deny_Listed_OrgIDs` is a string slice config key (env var `INGRESS_DENY_LISTED_ORGIDS`).
+- Denied org IDs result in HTTP 403. The deny list is converted to a map at handler creation time.
+
+## Debug Configuration
+
+- `Debug` (bool) and `DebugUserAgent` (regex pattern) work together: when both are set, requests matching the user-agent regex get full request dumps logged.
+- `DebugUserAgent` is compiled to a `*regexp.Regexp` at config load time.
+
+## Local Development Configuration
+
+- Use `development/.env` to set local env vars (sourced by the Makefile).
+- `make run-api` for S3/MinIO-backed local development.
+- `make run-filebased-api` for filesystem-backed local development.
+
+## Verification
+
+```bash
+# Confirm all config keys have SetDefault calls
+grep -c 'SetDefault' internal/config/config.go
+
+# Confirm env prefix is set
+grep 'SetEnvPrefix' internal/config/config.go
+
+# Confirm Clowder guard pattern exists
+grep 'IsClowderEnabled' internal/config/config.go
+
+# Check clowdapp.yaml declares expected INGRESS_ env vars
+grep 'INGRESS_' deploy/clowdapp.yaml
+
+# Verify config is imported by downstream packages
+grep -r 'internal/config' --include="*.go" cmd/ internal/
+```

--- a/docs/content-type-routing-guidelines.md
+++ b/docs/content-type-routing-guidelines.md
@@ -1,0 +1,77 @@
+# Content-Type Routing
+
+## Routing Architecture
+
+Uploads route to a single Kafka topic (`platform.upload.announce`). Downstream consumers distinguish payloads by the `service` Kafka header attached to each message, not by separate topics per service.
+
+## Content-Type Format and Parsing
+
+- Use the vendor MIME type pattern: `application/vnd.redhat.<service>.<category>` where `<service>` and `<category>` each contain only lowercase alphanumeric characters and hyphens (`[a-z0-9-]+`).
+- The regex in `internal/upload/validation.go` extracts `service` (capture group 1) and `category` (capture group 2) from the content type via `contentTypePat`:
+  ```
+  application/vnd\.redhat\.([a-z0-9-]+)\.([a-z0-9-]+).*
+  ```
+- Three legacy gzip content types are hardcoded to route to the `advisor` service with category `upload`:
+  - `application/x-gzip; charset=binary`
+  - `application/gzip`
+  - `application/gzip; charset=binary`
+- Any content type that does not match the vendor pattern or a legacy gzip variant results in HTTP 415.
+
+## Service Validation via ValidUploadTypes
+
+- `INGRESS_VALID_UPLOAD_TYPES` controls which service names are accepted. It is a comma-separated list.
+- `kafka.Validator.ValidateService()` in `internal/validators/kafka/kafka.go` checks the service name against a `map[string]bool` built from that list. Unrecognized service returns HTTP 415.
+- When adding a new upload type, add the service name to `INGRESS_VALID_UPLOAD_TYPES` in `deploy/clowdapp.yaml` and to `development/.env`.
+
+## Kafka Message Production
+
+- Validation messages are produced to the single announce topic (`platform.upload.announce` by default, remapped by Clowder when enabled).
+- The `service` value is attached as a Kafka message header (`{"service": "<service>"}`) in `kafka.Validator.Validate()`.
+- If upload metadata contains a `queue_key` field, it is used as the Kafka message key, enabling partition-based ordering.
+- Status messages go to `platform.payload-status` via `announcers.Kafka.Status()`.
+
+## Per-Service Max Size Overrides
+
+- `INGRESS_MAXSIZEMAP` is a JSON object mapping service names to byte-size strings (e.g., `{"qpc": "157286400"}`). Checked in `upload.NewHandler()` before `DefaultMaxSize`.
+- Exceeding the limit returns HTTP 413.
+
+## Response Codes by Content Type
+
+- `advisor` service uploads without metadata return HTTP 201.
+- All other service uploads return HTTP 202.
+- Invalid content type or unrecognized service: HTTP 415.
+- File size exceeded: HTTP 413.
+
+## ServiceDescriptor Struct
+
+- `validators.ServiceDescriptor` in `internal/validators/types.go` carries `Service` and `Category` strings. It is the routing key used by `ValidateService()`.
+- Populate both `Service` and `Category` from the content type; do not leave `Category` empty.
+
+## Testing Content-Type Routing
+
+- Use `validators.Fake` from `internal/validators/fake.go` in unit tests. It rejects service name `"failed"` and accepts everything else.
+- Tests in `internal/upload/upload_test.go` use the `boiler` helper with `FilePart` structs that set `ContentType` on the multipart file header.
+- Tests in `internal/validators/kafka/kafka_test.go` validate `ValidateService()` against a constructed valid-types list.
+
+## Clowder Topic Remapping
+
+- `config.GetTopic()` in `internal/config/config.go` translates a requested topic name to the Clowder-assigned name when `clowder.IsClowderEnabled()` is true. Use `config.GetTopic()` for any topic name resolution rather than hardcoding topic strings.
+
+## Verification
+
+```bash
+# Confirm content type regex compiles and has two capture groups
+grep -n 'contentTypePat' internal/upload/validation.go
+
+# Confirm valid upload types are set in deployment config
+grep 'INGRESS_VALID_UPLOAD_TYPES' deploy/clowdapp.yaml
+
+# Confirm Kafka header is set with the service name
+grep -A3 'Headers:' internal/validators/kafka/kafka.go
+
+# Confirm MaxSizeMap usage for per-service overrides
+grep -n 'MaxSizeMap' internal/upload/upload.go internal/config/config.go
+
+# Run unit tests for upload and kafka validator
+go test ./internal/upload/... ./internal/validators/kafka/...
+```

--- a/docs/data-validation-guidelines.md
+++ b/docs/data-validation-guidelines.md
@@ -1,0 +1,81 @@
+# Data Validation
+
+## Content-Type Validation
+
+- Parse the file part's `Content-Type` header (from the multipart MIME header, not the request header) using `getServiceDescriptor()` in `internal/upload/validation.go`.
+- Accept three legacy gzip content types as hardcoded aliases mapping to service `"advisor"` / category `"upload"`:
+  - `application/x-gzip; charset=binary`
+  - `application/gzip`
+  - `application/gzip; charset=binary`
+- For all other content types, match against the regex `application/vnd\.redhat\.([a-z0-9-]+)\.([a-z0-9-]+).*` where capture group 1 is the service name and group 2 is the category.
+- Return HTTP 415 when the content type matches neither the legacy aliases nor the regex pattern.
+- After extracting the `ServiceDescriptor`, call `validator.ValidateService()` to verify the service name exists in the `validUploadTypes` map. Return HTTP 415 if the service is not recognized.
+
+## Multipart Form Handling
+
+- Accept the payload file from either a `"file"` or `"upload"` form field name, tried in that order via `GetFile()` in `internal/upload/upload.go`. Return HTTP 400 if neither is found.
+- Pass `cfg.MaxUploadMem` (default 8 MB) to `r.ParseMultipartForm()` to control memory threshold before writing to disk.
+- Read metadata from a `"metadata"` form part, trying `r.FormFile("metadata")` first (as a file part), then `r.FormValue("metadata")` (as a form value). Metadata is optional; failure to read it is logged at Debug level and does not reject the request.
+
+## Metadata Schema
+
+- Deserialize metadata JSON into the `validators.Metadata` struct defined in `internal/validators/types.go`.
+- After unmarshaling, set `md.Reporter = "ingress"` and `md.StaleTimestamp = time.Now().AddDate(0, 0, 30)` -- these are overwritten regardless of client input.
+- All `Metadata` fields are optional (`omitempty` JSON tags) except `Reporter` and `StaleTimestamp`, which ingress populates.
+- The `QueueKey` field in metadata, when present, is used as the Kafka message key for partition routing.
+- Invalid metadata JSON causes metadata to be silently dropped, but the upload still proceeds.
+
+## File Size Validation
+
+- Check per-service size limits first via `cfg.MaxSizeMap[vr.Service]`, then fall back to `cfg.DefaultMaxSize` (default 100 MB).
+- `MaxSizeMap` values are strings parsed to `int64` with `strconv.ParseInt`. Provide values in bytes as strings (e.g., `"157286400"` for 150 MB).
+- Return HTTP 413 when the file exceeds the applicable limit.
+
+## Response Status Codes
+
+- Return 201 only when the service is `"advisor"` AND no metadata was provided.
+- Return 202 for all other successful uploads.
+- Return 200 for test/connection-check requests.
+- Return 403 for deny-listed org IDs.
+
+## Test Request Detection
+
+- `isTestRequest()` in `internal/upload/upload.go` detects two test patterns:
+  1. Form value `test=test` (current clients).
+  2. JSON body `{"test": "test"}` with `Content-Type: application/json` (legacy/satellite clients), matched via regex.
+- Test requests bypass all file and content-type validation and return HTTP 200.
+
+## Org ID Fallback
+
+- When `id.Identity.OrgID` is empty but `id.Identity.Internal.OrgID` is set, copy the internal value to the top-level `OrgID`. This fallback is applied before deny-list checking.
+
+## Validator Interface
+
+- Implement the `validators.Validator` interface (defined in `internal/validators/types.go`) with `Validate(*Request)` and `ValidateService(*ServiceDescriptor) error`.
+- `ValidateService` is the synchronous gate that rejects unknown services before staging. `Validate` is the async step that publishes to Kafka after staging.
+- Use `validators.Fake` for testing; it returns an error only when `service.Service == "failed"`.
+
+## Valid Upload Types Configuration
+
+- Configured via `INGRESS_VALID_UPLOAD_TYPES` as a comma-separated list (default: `"unit,announce"`).
+- Parsed in `internal/config/config.go` with `strings.Split(options.GetString("Valid_Upload_Types"), ",")`.
+- Passed as variadic args to `kafka.New()` which builds a `map[string]bool` lookup.
+
+## Verification
+
+```bash
+# Run all tests
+go test -p 1 -v ./...
+
+# Run upload validation tests only
+go test -v ./internal/upload/...
+
+# Verify the content-type regex compiles
+grep -n 'contentTypePat' internal/upload/validation.go
+
+# Check valid upload types default
+grep -n 'Valid_Upload_Types' internal/config/config.go
+
+# List all Fake test doubles
+grep -rn 'type Fake struct' internal/
+```

--- a/docs/dependency-management-guidelines.md
+++ b/docs/dependency-management-guidelines.md
@@ -1,0 +1,65 @@
+# Dependency Management
+
+## Module Configuration
+
+- Use the module path `github.com/redhatinsights/insights-ingress-go` as declared in `go.mod`.
+- Do not add `replace` directives to `go.mod`; the project relies on upstream module paths exclusively.
+- Do not vendor dependencies; no `vendor/` directory exists. The project uses Go module proxy resolution.
+- Commit both `go.mod` and `go.sum` together when changing dependencies.
+
+## Automated Dependency Updates
+
+- Renovate is configured in `renovate.json` and extends the shared preset at `github>RedHatInsights/konflux-pipelines//renovate/foreman_satellite/renovate.json`. Do not add inline package rules that duplicate the shared preset.
+- Dependabot (`.github/dependabot.yml`) is scoped solely to Docker base image updates on the `security-compliance` branch. Do not add `gomod` ecosystem entries to Dependabot; Go dependency updates are handled by Renovate.
+- A Renovate config validator workflow (`.github/workflows/renovate-validator-mintmaker.yaml`) runs on changes to `renovate.json`.
+
+## Key Direct Dependencies
+
+- **Kafka**: `github.com/confluentinc/confluent-kafka-go/v2` (cgo-based via librdkafka). On macOS, build and test with `-tags dynamic`. Production Docker builds on Linux do not require this tag.
+- **S3/Object Storage**: `github.com/minio/minio-go/v6` for S3-compatible storage. Do not introduce `aws-sdk-go` for S3 operations; `aws-sdk-go` is used only in `internal/logger/logger.go` for CloudWatch credentials.
+- **HTTP Router**: `github.com/go-chi/chi/v5`. Do not introduce alternative routers.
+- **Configuration**: `github.com/spf13/viper`.
+- **Logging**: `github.com/sirupsen/logrus` as the sole logging library.
+- **Red Hat Platform Libraries**: `github.com/redhatinsights/app-common-go` (Clowder) and `github.com/redhatinsights/platform-go-middlewares/v2` (identity/request-id middleware).
+- **Testing**: `github.com/onsi/ginkgo` (v1) and `github.com/onsi/gomega` for BDD-style tests. `github.com/jarcoal/httpmock` for HTTP mocking.
+- **Metrics**: `github.com/prometheus/client_golang` for Prometheus instrumentation.
+
+## Adding or Upgrading Dependencies
+
+- Prefer upgrading existing dependencies over introducing alternatives that serve the same purpose.
+- When adding a new direct dependency, ensure it appears under the `require` block (not just `indirect`). Run `go mod tidy` to clean up.
+- Avoid dependencies that require CGO beyond `confluent-kafka-go`, since the Docker build uses `ubi9/go-toolset` (builder) and `ubi9/ubi-minimal` (runtime with no C toolchain).
+
+## Hermetic / Konflux Builds
+
+- Tekton pipelines in `.tekton/` build with `hermetic: "true"` and prefetch Go modules via `prefetch-input: '[{"type": "gomod", "path": "."}]'`. Adding non-Go dependency types requires updating the `prefetch-input` parameter in all four Tekton PipelineRun YAMLs.
+- The Dockerfile does not run `go mod download` as a separate layer; dependencies are fetched implicitly during `go build`.
+
+## Docker Base Images
+
+- Builder stage: `registry.access.redhat.com/ubi9/go-toolset:latest`
+- Runtime stage: `registry.access.redhat.com/ubi9/ubi-minimal:latest`
+- Base image updates on `security-compliance` branch are automated by Dependabot.
+
+## Licenses
+
+- Place license files in the `licenses/` directory. The Dockerfiles copy `licenses/LICENSE` into the final image.
+
+## Verification
+
+```bash
+# Ensure go.mod and go.sum are tidy
+go mod tidy && git diff --exit-code go.mod go.sum
+
+# Build on macOS (requires -tags dynamic)
+make build
+
+# Run tests
+make test
+
+# Check for unintended replace directives
+grep '^replace' go.mod  # should produce no output
+
+# Check for vendor directory (should not exist)
+test ! -d vendor
+```

--- a/docs/deployment-guidelines.md
+++ b/docs/deployment-guidelines.md
@@ -1,0 +1,69 @@
+# Deployment
+
+## Container Images
+
+- Use multi-stage builds: `registry.access.redhat.com/ubi9/go-toolset:latest` for building, `registry.access.redhat.com/ubi9/ubi-minimal:latest` for runtime.
+- `Dockerfile` is the production image used by Tekton/Konflux pipelines. `Dockerfile.upstream` is for community/upstream builds via GitHub Actions. Keep them in sync except for the license copy path.
+- Run as non-root user `1001` in the final stage.
+- Build the binary with `go build -o insights-ingress-go cmd/insights-ingress/main.go` -- the entrypoint is `CMD ["/insights-ingress-go"]`.
+
+## ClowdApp Manifest (deploy/clowdapp.yaml)
+
+- The manifest is an OpenShift Template wrapping a `ClowdApp` of kind `cloud.redhat.com/v1alpha1`, named `ingress`.
+- The single deployment is named `service` with a public web service on API path `ingress`.
+- Health probes (liveness and readiness) use HTTP GET on `/` port `8000`, with `initialDelaySeconds: 35` and `timeoutSeconds: 120`.
+- Mount an `emptyDir` volume named `tmpdir` at `/tmp` inside the pod.
+- Declare two Kafka topics: `platform.payload-status` (3 partitions) and `platform.upload.announce` (64 partitions), each with 3 replicas.
+- Declare `objectStore` referencing the `INGRESS_STAGEBUCKET` parameter (default `insights-upload-perma`).
+- Hard dependencies: `puptoo`, `storage-broker`. Optional dependencies: `host-inventory`, `payload-tracker`.
+- When adding new env vars, prefix with `INGRESS_` and add a matching `parameters` entry with a sensible default.
+- `INGRESS_VALID_UPLOAD_TYPES` is a comma-separated allowlist -- append new types to the existing list.
+- `INGRESS_MAXSIZEMAP` is a JSON map of per-type size overrides (e.g., `{"qpc": "157286400"}`).
+- Resource defaults: CPU 200m/500m request/limit, memory 256Mi/512Mi request/limit.
+
+## Tekton / Konflux Pipelines (.tekton/)
+
+- Four PipelineRun manifests exist, split by branch and event:
+  - `ingress-pull-request.yaml` / `ingress-push.yaml` target the `master` branch.
+  - `ingress-sc-pull-request.yaml` / `ingress-sc-push.yaml` target the `security-compliance` branch.
+- Master-branch pipelines pin to a versioned Konflux pipeline ref. When bumping the pipeline version, update both `ingress-pull-request.yaml` and `ingress-push.yaml` to the same tag.
+- Master-branch builds enable hermetic mode (`hermetic: "true"`) with Go module prefetch. SC builds omit these parameters.
+- PR images include `image-expires-after: 5d`; push images do not expire.
+
+## GitHub Actions Workflows (.github/workflows/)
+
+- `pr.yml`: Runs `go test ./...` and validates `internal/api/openapi.json` with `openapi-spec-validator` on every PR.
+- `container-publish.yaml`: Builds via `Dockerfile.upstream`, pushes to `quay.io/iop/ingress`, and signs with cosign on push to `master` or semver tags.
+- `security-workflow-template.yml`: Invokes the reusable ConsoleDot platform security scan.
+- `renovate-validator-mintmaker.yaml`: Validates `renovate.json` changes.
+
+## CI Scripts (Bonfire / App-SRE)
+
+- `pr_check.sh` bootstraps Bonfire CICD, runs unit tests (`unit_test.sh`), deploys to ephemeral environment, and executes IQE smoke tests with plugin `ingress`.
+- `build_deploy.sh` builds and pushes to `quay.io/cloudservices/insights-ingress` using short git SHA as tag.
+- `unit_test.sh` runs tests with `ACG_CONFIG` pointing to `cdappconfig.json` at repo root.
+
+## Local Development
+
+- `development/local-dev-start.yml` runs Kafka (KRaft mode), Zookeeper, and MinIO via podman-compose.
+- Use `make start-api-dependencies` then `make run-api` for S3-backed local dev.
+- Use `make start-filebased-api-dependencies` then `make run-filebased-api` for file-based storage.
+
+## Verification
+
+```bash
+# Validate ClowdApp manifest is valid YAML
+python3 -c "import yaml; yaml.safe_load(open('deploy/clowdapp.yaml'))"
+
+# Check Dockerfile builds
+docker build -f Dockerfile -t ingress-test .
+
+# Verify Tekton PipelineRun manifests parse
+for f in .tekton/*.yaml; do python3 -c "import yaml; yaml.safe_load(open('$f'))"; done
+
+# Confirm unit tests pass with mock Clowder config
+ACG_CONFIG="$(pwd)/cdappconfig.json" go test -v ./...
+
+# Ensure Tekton pipelines reference consistent versions
+grep 'pipelinesascode.tekton.dev/pipeline' .tekton/ingress-pull-request.yaml .tekton/ingress-push.yaml
+```

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -1,0 +1,74 @@
+# Error Handling
+
+## Logging
+
+- Use the global `l.Log` logger from `internal/logger` (aliased as `l`), not `fmt.Println` or the standard `log` package.
+- Log errors using `logrus.Fields` with `{"error": err}` as the field key for attaching error values.
+- In HTTP handlers, define a local `logerr` closure that calls `requestLogger.WithFields(logrus.Fields{"error": err}).Error(msg)`, following the pattern in `internal/upload/upload.go` and `internal/track/track.go`.
+- Attach `request_id`, `source_host`, `account`, and `org_id` to the request-scoped logger. Add fields progressively as they become available.
+- Include `status_code` in log fields when logging HTTP error responses.
+- Use `Error` level for operational failures (staging errors, marshal failures, kafka producer errors). Use `Info` level for expected rejections (deny-listed org, invalid content type, authorization failures). Use `Debug` level for non-critical parse failures like missing optional metadata.
+- Reserve `Fatal` level for startup-blocking failures in `cmd/insights-ingress/main.go` only. Do not use `Fatal` in request handlers.
+
+## HTTP Status Codes
+
+The upload handler in `internal/upload/upload.go` uses these specific status codes:
+
+- `200 OK` -- test/connectivity requests only (`isTestRequest`)
+- `201 Created` -- advisor service uploads with no metadata
+- `202 Accepted` -- all other successful uploads
+- `400 Bad Request` -- missing `file`/`upload` multipart form field; invalid request ID in track handler
+- `403 Forbidden` -- deny-listed org ID; unauthorized track requests
+- `404 Not Found` -- no payload-tracker data for a request ID
+- `413 Request Entity Too Large` -- payload exceeds `DefaultMaxSize` or service-specific `MaxSizeMap` limit
+- `415 Unsupported Media Type` -- content type fails regex match or service not in valid upload types
+- `500 Internal Server Error` -- staging failure, JSON marshal failure, payload-tracker communication failure
+
+Preserve the `201` vs `202` distinction: return `201` only when `vr.Service == "advisor"` and metadata is nil.
+
+## Error Construction
+
+- Use `errors.New()` for static error messages.
+- Use `fmt.Errorf()` with `%v` for wrapping context in most places. Use `%w` wrapping only in `cmd/insights-ingress/main.go` for stager initialization errors.
+- In `internal/stage/s3compat/s3compat.go`, construct error messages by concatenating via `.Error()` into a new `errors.New()`.
+
+## Error Propagation
+
+- HTTP handler functions do not return errors. They write the status code and body directly, then `return`.
+- Interface methods (`Stager.Stage`, `Stager.GetURL`, `Validator.ValidateService`) return `(value, error)` tuples. The caller checks and responds with the appropriate HTTP status.
+- `Validator.Validate` does not return an error. If JSON marshaling fails inside `internal/validators/kafka/kafka.go`, the error is logged and the function returns silently.
+- `Kafka.Status` in `internal/announcers/kafka.go` logs marshal errors and returns without propagating.
+- Failed Kafka publishes are retried by re-enqueuing the message onto the channel in `internal/queue/queue.go`.
+- Metadata parsing errors (`GetMetadata`) are logged at `Debug` level and do not abort the request.
+
+## Error Response Bodies
+
+- Write plain-text error messages to the response body using `w.Write([]byte(...))` for client-facing errors (400, 403, 413). Do not return JSON-formatted error bodies.
+- For 415 and 500 errors, write only the status code header with no response body.
+- For successful responses (200, 201, 202), set `Content-Type: application/json` and write the JSON `responseBody` struct.
+
+## Panic Usage
+
+- `panic` is used only in `internal/config/config.go` for Kafka CA certificate write failure. Do not use `panic` elsewhere.
+- The `chi` `middleware.Recoverer` is registered in `cmd/insights-ingress/main.go` to catch panics in request handlers.
+
+## Prometheus Error Metrics
+
+- Increment `ingress_kafka_produce_failures` (in `internal/queue/queue.go`) when a Kafka publish fails.
+- Track response codes via `ingress_responses` counter with `useragent` and `code` labels in `internal/upload/metrics.go`.
+
+## Verification
+
+```bash
+# Confirm all error logs use logrus.Fields{"error": err} pattern
+grep -rn '\.Error(' internal/ cmd/ --include="*.go" | grep -v _test.go
+
+# Confirm no fmt.Println or log.Fatal usage outside main
+grep -rn 'fmt\.Println\|log\.Fatal\|log\.Print' internal/ --include="*.go"
+
+# Confirm panic is only in config.go
+grep -rn 'panic(' internal/ cmd/ --include="*.go" | grep -v _test.go
+
+# Run tests
+go test -p 1 -v ./...
+```

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -1,0 +1,60 @@
+# Integration
+
+## Storage (S3 / Filebased Staging)
+
+- Implement new storage backends by satisfying the `stage.Stager` interface defined in `internal/stage/types.go` (methods: `Stage(*Input) (string, error)` and `GetURL(requestID string) (string, error)`).
+- The S3-compatible client uses `minio/minio-go/v6` (not the AWS SDK) -- see `internal/stage/s3compat/s3compat.go`. Retain this library for S3 operations.
+- When staging to S3, attach `requestID`, `account`, and `org` as `UserMetadata` on `minio.PutObjectOptions`. Content type is hardcoded to `application/gzip`.
+- Presigned URLs use a 24-hour expiry via `PresignedGetObject`.
+- Stager selection is controlled by `config.IngressConfig.StagerImplementation` -- only `"s3"` and `"filebased"` are valid. The `getStager` function in `cmd/insights-ingress/main.go` is the single decision point.
+
+## Kafka
+
+- Use `confluent-kafka-go/v2` for all Kafka production -- see `internal/queue/queue.go`. Do not introduce a second Kafka client library.
+- The `queue.Producer` function consumes from a `chan validators.ValidationMessage` channel and produces to a single topic.
+- On delivery failure, the message is re-enqueued to the same input channel.
+- Two distinct Kafka producers exist at runtime: one for `platform.upload.announce`, one for `platform.payload-status`.
+- Topic names are resolved through `config.GetTopic()` which uses Clowder's `KafkaTopics` mapping when enabled.
+
+## Payload Tracker
+
+- Status announcements go through the `announcers.Announcer` interface defined in `internal/announcers/kafka.go`.
+- Two status events are emitted per successful upload: `"received"` (before staging) and `"success"` (after staging).
+- The `/track/{requestID}` endpoint in `internal/track/track.go` proxies to the payload-tracker HTTP service at `PayloadTrackerURL`.
+- Track endpoint validates request ID as UUID via `google/uuid`.
+- Authorization checks `OrgID` match, but bypasses for `Associate` identity type and trusted integration test certificates.
+
+## Platform Middlewares
+
+- Use `platform-go-middlewares/v2` (not v1). Import path: `github.com/redhatinsights/platform-go-middlewares/v2/identity` and `.../request_id`.
+- Request IDs extracted via `request_id.ConfiguredRequestID("x-rh-insights-request-id")` -- this custom header name is required.
+- Identity retrieved with `identity.GetIdentity(r.Context())` returning `identity.XRHID`.
+- When `OrgID` is empty but `Internal.OrgID` is populated, copy internal to top-level.
+- Auth enforcement uses `identity.EnforceIdentityWithLogger(identityErrorLogFunc)`.
+
+## Content Types and Validation
+
+- Content-type routing handled by `getServiceDescriptor` in `internal/upload/validation.go`.
+- Legacy gzip types map to service `"advisor"`, category `"upload"`.
+- Custom content types follow `application/vnd.redhat.{service}.{category}` pattern.
+- Service name checked against `ValidUploadTypes` configured via `INGRESS_VALID_UPLOAD_TYPES`.
+
+## Testing
+
+- Tests use Ginkgo/Gomega. Each test package has a `*_suite_test.go` bootstrap file.
+- Fake implementations: `stage.Fake`, `validators.Fake`, `announcers.Fake`. Use these instead of mocking.
+- HTTP tests use `httptest.NewRecorder` with `identity.WithIdentity` for context injection.
+- Track tests use `jarcoal/httpmock` to stub payload-tracker HTTP calls.
+
+## Verification
+
+```bash
+# Run all tests
+go test -p 1 -v ./...
+
+# Build the binary
+go build -o insights-ingress-go cmd/insights-ingress/main.go
+
+# Verify all interfaces are satisfied
+go vet ./...
+```

--- a/docs/logging-and-observability-guidelines.md
+++ b/docs/logging-and-observability-guidelines.md
@@ -1,0 +1,83 @@
+# Logging and Observability
+
+## Logger Access
+
+- Import the logger package as `l "github.com/redhatinsights/insights-ingress-go/internal/logger"` and use the global `l.Log` singleton. Do not create additional `logrus.Logger` instances.
+- Initialize the logger once via `l.InitLogger(cfg)` in `cmd/insights-ingress/main.go` before any log calls.
+- In test suites, call `l.InitLogger(config.Get())` in each Ginkgo `TestXxx` function before `RunSpecs`.
+
+## Structured Logging with logrus
+
+- Use `l.Log.WithFields(logrus.Fields{...})` for all log calls. Prefer structured fields over string interpolation.
+- In HTTP handlers, create a `requestLogger` by enriching `l.Log` with baseline fields, then chain additional fields as context grows:
+```go
+requestLogger := l.Log.WithFields(logrus.Fields{
+    "request_id":  reqID,
+    "source_host": cfg.Hostname,
+    "name":        "ingress",
+})
+```
+- Define a local `logerr` closure for repeated error logging within a handler:
+```go
+logerr := func(msg string, err error) {
+    requestLogger.WithFields(logrus.Fields{"error": err}).Error(msg)
+}
+```
+- Pass errors in fields using the key `"error"`, not as part of the message string.
+- Include `"request_id"` in fields for any log entry related to a specific request.
+
+## Log Levels
+
+- `DEBUG` -- internal processing details (metadata parse failures, topic posts, stage durations).
+- `INFO` -- request lifecycle events (payload received, sent to validation, denied uploads, startup).
+- `ERROR` -- actionable failures (Kafka producer errors, marshal failures, identity decode failures).
+- `Fatal` -- only for unrecoverable startup/shutdown failures.
+- Log level set via `INGRESS_LOGLEVEL` env var (values: `DEBUG`, `ERROR`, default `INFO`). During tests, log level is forced to `FatalLevel`.
+
+## CloudWatch Formatter
+
+- The `CustomCloudwatch` formatter in `internal/logger/logger.go` outputs JSON with fixed fields: `@timestamp`, `@version`, `message`, `levelname`, `source_host`, `app` (hardcoded to `"ingress"`), and `caller`.
+- `ReportCaller` is enabled on the logger.
+- CloudWatch hook is attached only when `AwsAccessKeyId` is non-empty. Uses `lc.NewBatchWriterWithDuration` from `platform-go-middlewares/v2/logging/cloudwatch` with a 10-second batch interval.
+
+## Request ID Tracing
+
+- Request IDs propagated via `x-rh-insights-request-id` HTTP header, configured with `request_id.ConfiguredRequestID("x-rh-insights-request-id")` middleware.
+- Retrieve with `request_id.GetReqID(r.Context())`.
+- Used as storage object key, in Kafka messages, payload tracker status, and response bodies.
+
+## Prometheus Metrics
+
+- Use `prometheus/client_golang/prometheus/promauto` (aliased `pa`) for metric registration. Metrics auto-register with the default registry.
+- Prefix all metric names with `ingress_`. Existing metrics:
+  - `internal/upload/metrics.go`: `ingress_requests`, `ingress_payload_sizes`, `ingress_stage_seconds`, `ingress_responses`
+  - `internal/validators/kafka/metrics.go`: `ingress_processed_payloads`, `ingress_validate_elapsed_seconds`, `ingress_message_produced`
+  - `internal/queue/queue.go`: `ingress_kafka_produced`, `ingress_publish_seconds`, `ingress_kafka_produce_failures`, `ingress_kafka_producer_go_routine_count`
+  - `internal/version/version.go`: `ingress_version` (created via `Namespace: "ingress"` + `Name: "version"`)
+- Declare metrics as package-level `var` blocks in dedicated `metrics.go` files. Keep metric helper functions unexported and co-located.
+- Normalize user-agent strings through `NormalizeUserAgent()` in `internal/upload/metrics.go` to prevent high-cardinality label explosion.
+- Metrics endpoint served on separate HTTP server on `MetricsPort` (default 8080) via `promhttp.Handler()` at `/metrics`.
+
+## Response Metrics Middleware
+
+- Wrap upload routes with `upload.ResponseMetricsMiddleware` to track response codes per user-agent via `metricTrackingResponseWriter`.
+
+## Grafana Dashboard
+
+- Dashboard definition at `dashboards/grafana-dashboard-insights-ingress-general.configmap.yaml`. When adding new metrics, verify they are referenced in this dashboard.
+
+## Verification
+
+```bash
+# Confirm all metrics use the ingress_ prefix
+grep -rn 'Name:' internal/upload/metrics.go internal/validators/kafka/metrics.go internal/queue/queue.go internal/version/version.go | grep -v 'ingress_'
+
+# Confirm logger is imported with the l alias
+grep -rn 'l "github.com/redhatinsights/insights-ingress-go/internal/logger"' internal/ cmd/
+
+# Confirm request_id field is present in handler log entries
+grep -rn 'request_id' internal/upload/upload.go internal/track/track.go
+
+# Confirm test suites initialize the logger
+grep -rn 'l\.InitLogger' internal/ --include="*_suite_test.go"
+```

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -1,0 +1,71 @@
+# Performance
+
+## Upload Memory and Size Limits
+
+- Set `MaxUploadMem` via `INGRESS_MAXUPLOADMEM` to control how much multipart form data is buffered in memory before spilling to disk. Default is 8 MB. Passed to `r.ParseMultipartForm` in `internal/upload/upload.go`.
+- Enforce per-service upload size limits by populating `MaxSizeMap` (env var `INGRESS_MAXSIZEMAP`) rather than raising `DefaultMaxSize` (default 100 MB).
+
+## Kafka Producer Concurrency
+
+- `queue.Producer` in `internal/queue/queue.go` spawns an unbounded goroutine for every message read from the input channel. The `producerCount` gauge (`ingress_kafka_producer_go_routine_count`) tracks active producer goroutines.
+- Validation producer channel is buffered at 100. Status announcer channel is buffered at 1000. Writes block when full, applying backpressure to the upload handler. Do not reduce these buffer sizes without understanding downstream throughput.
+- Failed Kafka messages are re-enqueued to the same input channel with no backoff or attempt limit.
+
+## HTTP Server Configuration
+
+- The `http.Server` instances in `cmd/insights-ingress/main.go` do not set `ReadTimeout`, `WriteTimeout`, `ReadHeaderTimeout`, or `IdleTimeout`. When modifying server configuration, prefer setting these timeouts.
+- `HTTPClientTimeout` (env var `INGRESS_HTTPCLIENTTIMEOUT`, default 10 seconds) controls the timeout for outbound HTTP client used by the track endpoint.
+
+## Resource Cleanup
+
+- Upload handler uses dual-close for the uploaded file: `defer file.Close()` as safety net, and `stageInput.Close()` after staging completes.
+- Kafka producer (`p.Close()`) is deferred in `queue.Producer`. Use `Kafka.Stop()` (which calls `close(k.In)`) for graceful shutdown.
+
+## Metrics Cardinality
+
+- User-Agent strings are normalized via `NormalizeUserAgent` in `internal/upload/metrics.go` before use as Prometheus labels. When adding new user-agent-labeled metrics, use `NormalizeUserAgent` consistently.
+- Avoid adding high-cardinality labels (request IDs, account numbers) to Prometheus metrics.
+- Histogram buckets for `ingress_payload_sizes` are 10 KB, 100 KB, 1 MB, and 10 MB.
+
+## Staging Performance
+
+- `ingress_stage_seconds` histogram tracks S3/filesystem staging latency.
+- Neither stager implementation streams data concurrently; staging is synchronous within the request handler.
+
+## Profiling
+
+- Set `INGRESS_PROFILE=true` to mount pprof endpoints at `/debug` via `middleware.Profiler()`. Keep disabled in production.
+
+## Graceful Shutdown
+
+- Main function uses `idleConnsClosed` channel and `signal.Notify` for SIGINT-based graceful shutdown. The shutdown has no timeout context, meaning it waits indefinitely for active connections to drain.
+
+## Deny List Optimization
+
+- Org ID deny list is converted from a slice to `map[string]bool` at handler construction time via `isRequestFromDenyListedOrgID`, not per-request. Preserve this closure-based approach.
+
+## Test Constraints
+
+- Tests run with `-p 1` (sequential, single process) to prevent race conditions from shared global state (Prometheus metric registrations via `promauto`).
+
+## Verification
+
+```bash
+# Check for unbounded goroutine spawning patterns
+grep -rn "go func" internal/ --include="*.go"
+
+# Verify channel buffer sizes
+grep -rn "make(chan" internal/ --include="*.go"
+
+# Confirm no HTTP server timeouts are set
+grep -rn "ReadTimeout\|WriteTimeout\|IdleTimeout\|ReadHeaderTimeout" cmd/ internal/ --include="*.go"
+
+# Verify MaxUploadMem is passed to ParseMultipartForm
+grep -rn "ParseMultipartForm" internal/ --include="*.go"
+
+# Confirm profiler is gated behind config flag
+grep -rn "Profile\|Profiler" cmd/ --include="*.go"
+
+# Run tests
+make test
+```

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -1,0 +1,71 @@
+# Security
+
+## Identity and Authentication
+
+- Retrieve caller identity via `identity.GetIdentity(r.Context())` which returns `identity.XRHID`. Identity is placed into context by `identity.EnforceIdentityWithLogger` middleware from `platform-go-middlewares/v2/identity`.
+- Guard all authenticated routes with `identity.EnforceIdentityWithLogger(identityErrorLogFunc)` as chi middleware. When `cfg.Auth` is `false`, identity middleware is skipped entirely.
+- Check `cfg.Auth` before calling `identity.GetIdentity(r.Context())`. Both `internal/upload/upload.go` and `internal/track/track.go` gate identity extraction on `cfg.Auth == true`.
+- When top-level `Identity.OrgID` is empty, fall back to `Identity.Internal.OrgID`. This fallback happens in `internal/upload/upload.go` and should be preserved on any new handler that consumes org identity.
+- Forward raw base64 identity header (`x-rh-identity`) to downstream validators via `B64Identity` field on `validators.Request`.
+
+## Org-ID Deny List
+
+- Configured via `INGRESS_DENY_LISTED_ORGIDS`, stored as `[]string` in `config.IngressConfig.DenyListedOrgIDs`.
+- Deny list check is implemented as a closure returned by `isRequestFromDenyListedOrgID` in `internal/upload/upload.go`. Converts slice to `map[string]bool` once at handler creation time.
+- Deny-listed requests receive HTTP 403 with body `"Upload denied. Please contact Red Hat Support."`.
+- Deny list check runs before file parsing and staging. Preserve this ordering to avoid unnecessary I/O for blocked orgs.
+
+## Track Endpoint Authorization
+
+- `/track/{requestID}` enforces authorization by comparing `id.Identity.OrgID` against the org ID from the payload-tracker response via `isIdAuthorized`.
+- Three identity types bypass the org-ID ownership check:
+  1. `Identity.Type == "Associate"` (internal Red Hat associate)
+  2. Trusted integration test X.509 certificates, identified by matching `SubjectDN` against `AutomatedIntegrationTestCertSubjectStage` and `AutomatedIntegrationTestCertSubjectProd` constants
+- Request IDs validated as UUIDs via `uuid.Parse` before any downstream call.
+
+## Kafka TLS and SASL Configuration
+
+- Kafka security protocol defaults to `"PLAINTEXT"`.
+- When Clowder is enabled and `broker.Authtype` is set, SASL credentials are read from Clowder broker config and stored in `config.KafkaSSLCfg`.
+- `queue.Producer` in `internal/queue/queue.go` conditionally sets `ssl.ca.location`, `security.protocol`, `sasl.mechanism`, `sasl.username`, and `sasl.password` only when corresponding config values are non-empty.
+- Both the validator producer and status announcer producer receive SSL/SASL config. When modifying Kafka producer configuration, update both paths in `cmd/insights-ingress/main.go`.
+
+## Object Storage TLS
+
+- MinIO/S3-compatible client in `internal/stage/s3compat/s3compat.go` uses `StorageCfg.UseSSL` to toggle TLS. When Clowder is enabled, `UseSSL` is set from `cfg.ObjectStore.Tls`.
+
+## Debug Mode
+
+- When `cfg.Debug` is true and `User-Agent` matches `cfg.DebugUserAgent` (compiled regex), full HTTP request including body is dumped to logs via `httputil.DumpRequest(r, true)`.
+- Avoid enabling `INGRESS_DEBUG` in production. Request dump includes `x-rh-identity` header and full payload body.
+
+## Content-Type as Security Boundary
+
+- Content-type validated against regex in `internal/upload/validation.go`. Extracted service name checked against `ValidUploadTypes`. Only explicitly allowed service types can submit payloads.
+
+## File-Based Stager
+
+- File-based stager sanitizes request IDs via `filterAlphanumeric`, stripping all non-letter/non-digit characters before constructing file paths.
+- The `/download/{requestID}` endpoint is mounted without identity middleware. Downloads are unauthenticated when using file-based stager.
+
+## Verification
+
+```bash
+# Confirm identity middleware is applied
+grep -n "EnforceIdentityWithLogger" cmd/insights-ingress/main.go
+
+# Confirm deny list check runs before file processing
+grep -n "isRequestFromDenyListedOrgID\|isCustomerDenyListed" internal/upload/upload.go
+
+# Confirm SASL/TLS config is propagated to both producer configs
+grep -n "KafkaSSLConfig" cmd/insights-ingress/main.go
+
+# Confirm track endpoint validates request ID as UUID
+grep -n "isValidUUID\|uuid.Parse" internal/track/track.go
+
+# Confirm file-based stager sanitizes request IDs
+grep -n "filterAlphanumeric" internal/stage/filebased/filebased.go
+
+# Run security-relevant tests
+go test ./internal/upload/... ./internal/track/... ./internal/validators/kafka/...
+```

--- a/docs/storage-patterns-guidelines.md
+++ b/docs/storage-patterns-guidelines.md
@@ -1,0 +1,67 @@
+# Storage Patterns
+
+## Stager Interface
+
+- Implement new storage backends by satisfying the `stage.Stager` interface defined in `internal/stage/types.go`. Methods: `Stage(*Input) (string, error)` and `GetURL(requestID string) (string, error)`.
+- `Stage` persists the payload and returns a URL; `GetURL` returns a retrieval URL for a previously staged payload.
+- Populate `stage.Input` with `Payload` (an `io.ReadCloser`), `Key` (the request ID), `Account`, `OrgId`, and `Size`.
+- Register new stager implementations in `getStager` in `cmd/insights-ingress/main.go`, keyed by `StagerImplementation` config.
+
+## S3-Compatible Storage (s3compat)
+
+- S3 backend lives in `internal/stage/s3compat/s3compat.go` and uses `github.com/minio/minio-go/v6`. Do not upgrade to v7 without updating all call sites.
+- `S3Stager` holds a `Bucket` string and a `*minio.Client`. Initialize via `s3compat.GetClient`, which reads from `config.StorageCfg`.
+- When `StorageEndpoint` is empty, client defaults to `s3.amazonaws.com`. When `StorageRegion` is set, use `minio.NewWithRegion`; otherwise use `minio.New`.
+- `Stage` uploads with content type hardcoded to `"application/gzip"` and attaches `requestID`, `account`, and `org` as S3 user metadata.
+- `GetURL` generates presigned GET URLs with a 24-hour TTL (`time.Second * 24 * 60 * 60`).
+- Default staging bucket name is `"available"`. In Clowder, bucket name comes from `clowder.ObjectBuckets`.
+
+## File-Based Storage (filebased)
+
+- File-based backend lives in `internal/stage/filebased/filebased.go`. Selected when `StagerImplementation` equals `"filebased"`.
+- `FileBasedStager` requires `StagePath` (directory) and `BaseURL` (service URL prefix).
+- Stored files named `<sanitized-request-id>.tar.gz`. The `filterAlphanumeric` function strips all non-letter/non-digit characters from the request ID.
+- `GetURL` constructs download URLs as `<BaseURL>/download/<requestID>`.
+- Download handler registered at `/download/{requestID}` only when stager is `"filebased"`.
+- Download endpoint in `internal/download/download.go` sets `Content-Disposition` and `Content-Type: application/gzip`, serves via `http.ServeFile`.
+
+## Configuration Environment Variables
+
+- Storage config uses `INGRESS_` prefix. Key variables: `INGRESS_STAGERIMPLEMENTATION`, `INGRESS_STAGEBUCKET`, `INGRESS_MINIOENDPOINT`, `INGRESS_MINIOACCESSKEY`, `INGRESS_MINIOSECRETKEY`, `INGRESS_USESSL`, `INGRESS_STORAGEREGION`, `INGRESS_STORAGEFILESYSTEMPATH`, `INGRESS_SERVICEBASEURL`.
+- Config maps `MinioEndpoint`/`MinioAccessKey`/`MinioSecretKey` viper keys to `StorageEndpoint`/`StorageAccessKey`/`StorageSecretKey` struct fields. Use `Minio*` key names in env vars.
+
+## Testing Fakes
+
+- Use `stage.Fake` from `internal/stage/fake.go` to mock the stager. Set `ShouldError` for failure paths. Access `StageCalled()` and `GetURLCalled()` (thread-safe via mutex).
+- File-based tests use `t.TempDir()` or `os.MkdirTemp` for storage directory.
+
+## Upload Flow and Stage Integration
+
+- Upload handler constructs `stage.Input` using request ID as `Key`, multipart file as `Payload`, and identity-derived `Account`/`OrgId`/`Size`.
+- After `stager.Stage` returns, handler calls `stageInput.Close()` explicitly. Redundant deferred close is intentional.
+- Stage duration tracked via `ingress_stage_seconds` Prometheus histogram.
+- Staged URL set on `validators.Request.URL` for downstream consumption.
+
+## Local Development
+
+- S3 mode: `make run-api` with MinIO via `make start-api-dependencies`. Compose file creates `insights-upload-perma` bucket.
+- File-based mode: `make run-filebased-api` sets `INGRESS_STAGERIMPLEMENTATION=filebased`.
+
+## Verification
+
+```bash
+# Confirm Stager interface is satisfied by both implementations
+grep -n "stage.Stager" internal/stage/s3compat/s3compat.go cmd/insights-ingress/main.go
+
+# Confirm presigned URL TTL is 24 hours
+grep -n "time.Second\*24" internal/stage/s3compat/s3compat.go
+
+# Confirm filebased filename sanitization
+grep -n "filterAlphanumeric\|\.tar\.gz" internal/stage/filebased/filebased.go
+
+# Confirm both stager implementations are wired in getStager
+grep -n "StagerImplementation" cmd/insights-ingress/main.go
+
+# Run tests
+go test -p 1 -v ./internal/stage/... ./internal/upload/... ./internal/download/...
+```

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -1,0 +1,84 @@
+# Testing
+
+## Test Framework and Imports
+
+- Use Ginkgo v1 (`github.com/onsi/ginkgo`) and Gomega (`github.com/onsi/gomega`) for all tests. Do not use Ginkgo v2.
+- Dot-import both Ginkgo and Gomega in test files: `. "github.com/onsi/ginkgo"` and `. "github.com/onsi/gomega"`.
+- Dot-import the package under test when tests are in an `_test` package.
+
+## Suite Files
+
+- Each tested package has a `*_suite_test.go` file containing a single `Test*` function that bootstraps the Ginkgo runner.
+- Initialize configuration and logger in every suite bootstrap function before `RunSpecs`:
+  ```go
+  func TestUpload(t *testing.T) {
+      cfg := config.Get()
+      RegisterFailHandler(Fail)
+      l.InitLogger(cfg)
+      RunSpecs(t, "Upload Suite")
+  }
+  ```
+- The logger initialization via `l.InitLogger(cfg)` is required to avoid nil pointer panics.
+
+## Test Structure
+
+- Use `Describe` at the top level to name the component or function under test.
+- Use `Context` to describe the specific scenario or input condition.
+- Use `It` to state the expected outcome.
+- Prefer `BeforeEach` over shared setup at the `Describe` level for mutable state.
+
+## Fakes and Mocking
+
+- Use in-repo fake implementations for dependency injection:
+  - `stage.Fake` (`internal/stage/fake.go`) for `Stager`. Set `ShouldError: true` to simulate failures.
+  - `validators.Fake` (`internal/validators/fake.go`) for `Validator`. Inspect `validator.In` after request to assert on `validators.Request`.
+  - `announcers.Fake` (`internal/announcers/fake.go`) for `Announcer`.
+- For external HTTP dependencies (payload-tracker), use `github.com/jarcoal/httpmock`. Call `httpmock.Activate()` in `BeforeEach`.
+
+## HTTP Handler Testing
+
+- Use `net/http/httptest.NewRecorder()` to capture handler responses.
+- Construct handlers via `NewHandler` factory functions, passing fakes and `config.IngressConfig`.
+- Wrap upload handlers with `request_id.ConfiguredRequestID("x-rh-insights-request-id")` middleware when the handler reads request IDs from context.
+- Set identity context using `identity.WithIdentity(ctx, identity.XRHID{...})` from `platform-go-middlewares/v2/identity`.
+- For chi router URL params, inject via `chi.NewRouteContext()` and add to request context with `chi.RouteCtxKey`.
+
+## Multipart Upload Requests
+
+- Build multipart requests using a local helper function with `multipart.Writer` parts and explicit MIME headers.
+- Use a `FilePart` struct with `Name`, `Content`, and `ContentType` fields.
+- Accepted part names for file uploads are `"file"` and `"upload"`.
+
+## Config Overrides in Tests
+
+- Override config values by modifying `*config.IngressConfig` returned from `config.Get()` before passing to `NewHandler`. Do not set environment variables in tests.
+- Example: set `cfg.DefaultMaxSize = 1` to test size limits, set `cfg.DenyListedOrgIDs` for deny-list tests.
+
+## Assertions
+
+- Use `Expect(rr.Code).To(Equal(http.StatusOK))` for status codes.
+- Use `Expect(err).To(BeNil())` for error checks (not `Expect(err).ToNot(HaveOccurred())`; the codebase consistently uses `BeNil()`).
+- Inspect fake state after handler execution: `Expect(stager.StageCalled()).To(BeTrue())`.
+
+## Running Tests
+
+- Run all tests sequentially (required): `go test -p 1 -v ./...`
+- Run with race detection (CI mode): `go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...`
+- CI sets `ACG_CONFIG` pointing to `cdappconfig.json`: `ACG_CONFIG="$(pwd)/cdappconfig.json" go test ...`
+- On macOS, build tags required: `go test -tags dynamic -p 1 -v ./...`
+
+## Verification
+
+```bash
+# Run the full test suite
+go test -p 1 -v ./...
+
+# Confirm all suite files initialize config and logger
+grep -rn "l.InitLogger" --include='*_suite_test.go' internal/
+
+# Confirm Ginkgo v1 dot-imports in all test files
+grep -rn '"github.com/onsi/ginkgo"' --include='*_test.go' internal/
+
+# Verify fakes exist for all injected interfaces
+ls internal/stage/fake.go internal/validators/fake.go internal/announcers/fake.go
+```


### PR DESCRIPTION
This PR was generated by the /init-context-docs Claude skill from https://github.com/OpenShift-Fleet/agentic-sdlc.

## Summary

- **15 domain-specific guideline files** in `docs/` covering api-contracts, async-messaging, code-organization, configuration, content-type-routing, data-validation, dependency-management, deployment, error-handling, integration, logging-and-observability, performance, security, storage-patterns, and testing
- **AGENTS.md** with cross-cutting conventions and a guidelines index (open standard for any AI agent)
- **CLAUDE.md** with Claude Code-specific build/test commands and `@AGENTS.md` import
- **.coderabbit.yaml** pointing CodeRabbit to guideline files for automated PR review
- **.claude/rules/*.md** for path-scoped guideline auto-loading in Claude Code
- **README.md** updated with Go 1.25, documentation links, tech stack table, project structure, and improved local development instructions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)