### PR TITLE
fix: bump Go to 1.25.9 for CVE-2026-32282, CVE-2026-32281

### DIFF
--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -2,9 +2,6 @@ FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
 
 WORKDIR /go/src/app
 
-# Specify Go toolchain version; "auto" allows go.mod to select a newer version
-ARG GOTOOLCHAIN=go1.25.9+auto
-
 COPY cmd cmd
 
 COPY internal internal

--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -2,9 +2,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
 
 WORKDIR /go/src/app
 
-# The current ubi9 image does not include Go 1.24, so we specify it.
-# Adding "auto" will allow a newer version to be downloaded if specified in go.mod
-ARG GOTOOLCHAIN=go1.24.4+auto
+# Specify Go toolchain version; "auto" allows go.mod to select a newer version
+ARG GOTOOLCHAIN=go1.25.9+auto
 
 COPY cmd cmd
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/insights-ingress-go
 
-go 1.24.4
+go 1.25.9
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8


### PR DESCRIPTION
## Summary

- Bumps Go minimum version from 1.24.4 (EOL, no security backports) to 1.25.9
- Removes `GOTOOLCHAIN` in `Dockerfile.upstream` - the base image comes with 1.26.4
- The base image resolves these CVEs however pinning the go.mod prevents future compilation with older versions:
  - **CVE-2026-32282**: `os.Root.Chmod` symlink traversal on Linux (CVSS 6.4)
  - **CVE-2026-32281**: `crypto/x509` DoS via inefficient certificate chain validation

## Test plan

- [x] `go mod tidy` — no dependency changes
- [x] `go build` — compiles successfully with Go 1.25.9+
- [x] `podman build` — container image builds cleanly (verified on foreman-3.16)

Ref: SAT-44183, SAT-45510