### PR TITLE
Revert "Remove puptoo from dependencies (#765)"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -13,6 +13,7 @@ objects:
     testing:
       iqePlugin: ingress
     dependencies:
+    - puptoo
     - storage-broker
     optionalDependencies:
     - host-inventory


### PR DESCRIPTION
This reverts commit ae24b33031eac326e12896abc7814308d8c9fc4c.

## What?
Moving back to having puptoo dependency

## Why?
Other applications pr checks got broken as they depend on ingress which was depending on puptoo. Since dependency has been removed, puptoo stopped being deployed and pr checks are failing.

There is a huge long thread about it in slack https://redhat-internal.slack.com/archives/C69UN1L4E/p1784003263792889 
feel free to scroll down to see puptoo discussion with Frantisek

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
