### PR TITLE
Add HCC cluster datasources to Grafana dashboard

### DIFF
--- a/dashboards/grafana-dashboard-insights-ingress-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-ingress-general.configmap.yaml
@@ -912,18 +912,33 @@ data:
               "text": "crcp01ue1-prometheus",
               "value": "crcp01ue1-prometheus"
             },
-            "hide": 0,
             "includeAll": false,
-            "label": "datasource",
-            "multi": false,
+            "label": "environment",
             "name": "datasource",
-            "options": [],
-            "query": "prometheus",
-            "queryValue": "",
-            "refresh": 1,
-            "regex": "/^crcs*./",
-            "skipUrlSync": false,
-            "type": "datasource"
+            "options": [
+              {
+                "selected": false,
+                "text": "crcs02ue1-prometheus",
+                "value": "crcs02ue1-prometheus"
+              },
+              {
+                "selected": true,
+                "text": "crcp01ue1-prometheus",
+                "value": "crcp01ue1-prometheus"
+              },
+              {
+                "selected": false,
+                "text": "hccs01ue1-prometheus",
+                "value": "hccs01ue1-prometheus"
+              },
+              {
+                "selected": false,
+                "text": "hccp01ue1-prometheus",
+                "value": "hccp01ue1-prometheus"
+              }
+            ],
+            "query": "crcs02ue1-prometheus, crcp01ue1-prometheus, hccs01ue1-prometheus, hccp01ue1-prometheus",
+            "type": "custom"
           }
         ]
       },


### PR DESCRIPTION
## Summary

- Switch dashboard datasource variable from regex-based auto-discovery (`/^crcs*./`) to explicit custom list
- Add `hccs01ue1-prometheus` and `hccp01ue1-prometheus` datasources alongside existing CRC ones
- Matches the pattern used by export-service dashboard

Part of epic [RHCLOUD-49011](https://issues.redhat.com/browse/RHCLOUD-49011) — Dual Deployment of Ingress to HCC Cluster.

[RHCLOUD-49011]: https://redhat.atlassian.net/browse/RHCLOUD-49011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ