### PR TITLE
feat: pin go base image to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ################################
 # STEP 1 build executable binary
 ################################
-FROM registry.access.redhat.com/hi/go:latest-fips-builder AS builder
+FROM registry.access.redhat.com/hi/go:1.26-fips-builder AS builder
 
 USER 0
 
@@ -23,7 +23,7 @@ RUN go build -ldflags "-w -s" -o insights-ingress-go cmd/insights-ingress/main.g
 ############################
 # STEP 2 build a small image
 ############################
-FROM registry.access.redhat.com/hi/go:latest-fips
+FROM registry.access.redhat.com/hi/go:1.26-fips
 
 WORKDIR /
 


### PR DESCRIPTION
## What?

Pins the golang base image to to version 1.26

## Why?

To align with current RHEL's offerings https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle

and ease of rebase for the on-premise variants.

## How?

`:1.26-fips` tags used

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
