### PR TITLE
fix(upload): reject oversized bodies before buffering to disk (RHCLOUD-49841)

### DIFF
--- a/cmd/insights-ingress/main.go
+++ b/cmd/insights-ingress/main.go
@@ -166,8 +166,10 @@ func main() {
 	l.Log.WithFields(logrus.Fields{"Web Port": cfg.WebPort}).Info("Starting Service with mode " + cfg.StagerImplementation)
 
 	srv := http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.WebPort),
-		Handler: r,
+		Addr:              fmt.Sprintf(":%d", cfg.WebPort),
+		Handler:           r,
+		ReadTimeout:       time.Second * cfg.HTTPReadTimeout,
+		ReadHeaderTimeout: time.Second * cfg.HTTPReadHeaderTimeout,
 	}
 
 	l.Log.WithFields(logrus.Fields{"Metrics Port": cfg.MetricsPort}).Info("Starting Service")

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -71,11 +71,14 @@ objects:
           limits:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
+            ephemeral-storage: ${EPHEMERAL_STORAGE_LIMIT}
           requests:
             cpu: ${CPU_REQUESTS}
             memory: ${MEMORY_REQUESTS}
+            ephemeral-storage: ${EPHEMERAL_STORAGE_REQUESTS}
         volumes:
-        - emptyDir: {}
+        - emptyDir:
+            sizeLimit: ${TMPDIR_SIZE_LIMIT}
           name: tmpdir
         volumeMounts:
         - mountPath: /tmp
@@ -117,6 +120,15 @@ parameters:
 - description: memory request for service
   name: MEMORY_REQUESTS
   value: 256Mi
+- description: ephemeral storage limit of service
+  name: EPHEMERAL_STORAGE_LIMIT
+  value: 1Gi
+- description: ephemeral storage request for service
+  name: EPHEMERAL_STORAGE_REQUESTS
+  value: 512Mi
+- description: size limit for the /tmp emptyDir volume used to buffer uploads
+  name: TMPDIR_SIZE_LIMIT
+  value: 512Mi
 - name: MIN_REPLICAS
   value: '1'
 - description: Image tag

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,27 +15,29 @@ import (
 
 // IngressConfig represents the runtime configuration
 type IngressConfig struct {
-	Hostname             string
-	DefaultMaxSize       int64
-	MaxSizeMap           map[string]string
-	MaxUploadMem         int64
-	Auth                 bool
-	KafkaConfig          KafkaCfg
-	WebPort              int
-	MetricsPort          int
-	HTTPClientTimeout    time.Duration
-	Profile              bool
-	OpenshiftBuildCommit string
-	Version              string
-	PayloadTrackerURL    string
-	TlsCAPath            string
-	StorageConfig        StorageCfg
-	LoggingConfig        LoggingCfg
-	DenyListedOrgIDs     []string
-	Debug                bool
-	DebugUserAgent       *regexp.Regexp
-	ServiceBaseURL       string
-	StagerImplementation string
+	Hostname              string
+	DefaultMaxSize        int64
+	MaxSizeMap            map[string]string
+	MaxUploadMem          int64
+	Auth                  bool
+	KafkaConfig           KafkaCfg
+	WebPort               int
+	MetricsPort           int
+	HTTPClientTimeout     time.Duration
+	HTTPReadTimeout       time.Duration
+	HTTPReadHeaderTimeout time.Duration
+	Profile               bool
+	OpenshiftBuildCommit  string
+	Version               string
+	PayloadTrackerURL     string
+	TlsCAPath             string
+	StorageConfig         StorageCfg
+	LoggingConfig         LoggingCfg
+	DenyListedOrgIDs      []string
+	Debug                 bool
+	DebugUserAgent        *regexp.Regexp
+	ServiceBaseURL        string
+	StagerImplementation  string
 }
 
 type KafkaCfg struct {
@@ -139,6 +141,8 @@ func Get() *IngressConfig {
 	options.SetDefault("PayloadTrackerURL", "http://payload-tracker/v1/payloads/")
 	options.SetDefault("TlsCAPath", "")
 	options.SetDefault("HTTPClientTimeout", 10)
+	options.SetDefault("HTTPReadTimeout", 900)
+	options.SetDefault("HTTPReadHeaderTimeout", 10)
 	options.SetDefault("Auth", true)
 	options.SetDefault("DefaultMaxSize", 100*1024*1024)
 	options.SetDefault("MaxSizeMap", `{}`)
@@ -212,22 +216,24 @@ func Get() *IngressConfig {
 	}
 
 	IngressCfg := &IngressConfig{
-		Hostname:             options.GetString("Hostname"),
-		DefaultMaxSize:       options.GetInt64("DefaultMaxSize"),
-		MaxSizeMap:           options.GetStringMapString("MaxSizeMap"),
-		MaxUploadMem:         options.GetInt64("MaxUploadMem"),
-		Auth:                 options.GetBool("Auth"),
-		WebPort:              options.GetInt("WebPort"),
-		MetricsPort:          options.GetInt("MetricsPort"),
-		HTTPClientTimeout:    time.Duration(options.GetInt("HTTPClientTimeout")),
-		OpenshiftBuildCommit: kubenv.GetString("Openshift_Build_Commit"),
-		Version:              os.Getenv("1.0.8"),
-		PayloadTrackerURL:    options.GetString("PayloadTrackerURL"),
-		TlsCAPath:            options.GetString("TlsCAPath"),
-		Profile:              options.GetBool("Profile"),
-		DenyListedOrgIDs:     options.GetStringSlice("Deny_Listed_OrgIDs"),
-		Debug:                options.GetBool("Debug"),
-		DebugUserAgent:       regexp.MustCompile(options.GetString("DebugUserAgent")),
+		Hostname:              options.GetString("Hostname"),
+		DefaultMaxSize:        options.GetInt64("DefaultMaxSize"),
+		MaxSizeMap:            options.GetStringMapString("MaxSizeMap"),
+		MaxUploadMem:          options.GetInt64("MaxUploadMem"),
+		Auth:                  options.GetBool("Auth"),
+		WebPort:               options.GetInt("WebPort"),
+		MetricsPort:           options.GetInt("MetricsPort"),
+		HTTPClientTimeout:     time.Duration(options.GetInt("HTTPClientTimeout")),
+		HTTPReadTimeout:       time.Duration(options.GetInt("HTTPReadTimeout")),
+		HTTPReadHeaderTimeout: time.Duration(options.GetInt("HTTPReadHeaderTimeout")),
+		OpenshiftBuildCommit:  kubenv.GetString("Openshift_Build_Commit"),
+		Version:               os.Getenv("1.0.8"),
+		PayloadTrackerURL:     options.GetString("PayloadTrackerURL"),
+		TlsCAPath:             options.GetString("TlsCAPath"),
+		Profile:               options.GetBool("Profile"),
+		DenyListedOrgIDs:      options.GetStringSlice("Deny_Listed_OrgIDs"),
+		Debug:                 options.GetBool("Debug"),
+		DebugUserAgent:        regexp.MustCompile(options.GetString("DebugUserAgent")),
 		KafkaConfig: KafkaCfg{
 			KafkaBrokers:          options.GetStringSlice("KafkaBrokers"),
 			KafkaGroupID:          options.GetString("KafkaGroupID"),

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -34,13 +34,35 @@ type uploadData struct {
 	OrgID   string `json:"org_id,omitempty"`
 }
 
-// GetFile verifies that the proper upload field is in place and returns the file
-func GetFile(r *http.Request, m int64) (multipart.File, *multipart.FileHeader, error) {
+// multipartOverhead is headroom added to the largest allowed file size when
+// enforcing an early request-body limit. It accounts for multipart encoding
+// (boundaries, part headers) and the metadata part that accompany the file.
+const multipartOverhead = 1 * 1024 * 1024
+
+// maxRequestBodySize returns the largest multipart request body ingress will
+// accept before rejecting it outright. It is the largest configured per-service
+// or default file-size limit plus multipartOverhead, so http.MaxBytesReader can
+// reject oversized bodies before ParseMultipartForm buffers them to disk.
+func maxRequestBodySize(cfg config.IngressConfig) int64 {
+	max := cfg.DefaultMaxSize
+	for _, val := range cfg.MaxSizeMap {
+		if size, err := strconv.ParseInt(val, 10, 64); err == nil && size > max {
+			max = size
+		}
+	}
+	return max + multipartOverhead
+}
+
+// GetFile verifies that the proper upload field is in place and returns the file.
+// r.Body is wrapped with http.MaxBytesReader so an oversized multipart body is
+// rejected while streaming, before it is buffered to disk by ParseMultipartForm.
+func GetFile(w http.ResponseWriter, r *http.Request, m int64, maxBodySize int64) (multipart.File, *multipart.FileHeader, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 	// Reduce memory usage of multipart form. This indicates of memory will be used
 	// before writting to disk. Default: 8MB
 	err := r.ParseMultipartForm(m)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to parse form data: %v", err)
+		return nil, nil, fmt.Errorf("unable to parse form data: %w", err)
 	}
 
 	file, fileHeader, fileErr := r.FormFile("file")
@@ -146,6 +168,7 @@ func NewHandler(
 	cfg config.IngressConfig) http.HandlerFunc {
 
 	isCustomerDenyListed := isRequestFromDenyListedOrgID(cfg)
+	maxBodySize := maxRequestBodySize(cfg)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		var id identity.XRHID
@@ -187,8 +210,17 @@ func NewHandler(
 		}
 
 		incRequests(userAgent)
-		file, fileHeader, err := GetFile(r, cfg.MaxUploadMem)
+		file, fileHeader, err := GetFile(w, r, cfg.MaxUploadMem, maxBodySize)
 		if err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				errString := fmt.Sprintf("Upload body exceeds maximum size of %v bytes", maxBodySize)
+				w.WriteHeader(http.StatusRequestEntityTooLarge)
+				w.Write([]byte(errString))
+				requestLogger.WithFields(logrus.Fields{"request_id": reqID, "status_code": http.StatusRequestEntityTooLarge, "account": id.Identity.AccountNumber, "org_id": id.Identity.OrgID}).Info(errString)
+				logerr("Upload body too large", err)
+				return
+			}
 			errString := "File or upload field not found"
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(errString))

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -440,6 +440,43 @@ var _ = Describe("Upload", func() {
 			})
 		})
 
+		Context("with a request body larger than the max request body size", func() {
+			It("should return 413 via MaxBytesReader without staging", func() {
+				cfg := config.Get()
+				cfg.DefaultMaxSize = 1
+				handler = NewHandler(stager, validator, tracker, *cfg)
+				req, err := makeMultipartRequest("/api/ingress/v1/upload", &FilePart{
+					Name:        "file",
+					Content:     strings.Repeat("a", 2*1024*1024),
+					ContentType: "application/vnd.redhat.unit.test",
+				})
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(http.StatusRequestEntityTooLarge))
+				Expect(rr.Body.String()).To(ContainSubstring("Upload body exceeds maximum size"))
+				Expect(stager.StageCalled()).To(BeFalse())
+			})
+		})
+
+		Context("with a per-service limit larger than the body", func() {
+			It("should accept a body above DefaultMaxSize but under the service ceiling", func() {
+				TypeMap := map[string]string{"qpc": strconv.Itoa(4 * 1024 * 1024)}
+				cfg := config.Get()
+				cfg.DefaultMaxSize = 1
+				cfg.MaxSizeMap = TypeMap
+				handler = NewHandler(stager, validator, tracker, *cfg)
+				req, err := makeMultipartRequest("/api/ingress/v1/upload", &FilePart{
+					Name:        "file",
+					Content:     strings.Repeat("a", 2*1024*1024),
+					ContentType: "application/vnd.redhat.qpc.test",
+				})
+				Expect(err).To(BeNil())
+				handler.ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(http.StatusAccepted))
+				Expect(stager.StageCalled()).To(BeTrue())
+			})
+		})
+
 		Context("when the payload fails to stage", func() {
 			It("should return 413", func() {
 				stager = &stage.Fake{ShouldError: true}


### PR DESCRIPTION
## Summary

Fixes [RHCLOUD-49841](https://redhat.atlassian.net/browse/RHCLOUD-49841) — disk-fill DoS (CWE-770).

`/upload` called `ParseMultipartForm`, buffering the full request body to `/tmp` **before** the size check ran. An authenticated tenant could stream an arbitrarily large multipart body to saturate the pod's ephemeral storage.

## Changes

- **Early reject**: `GetFile` wraps `r.Body` with `http.MaxBytesReader` before `ParseMultipartForm`, sized to the largest configured file limit (`DefaultMaxSize` / per-service `MaxSizeMap`) plus multipart overhead. Handler returns **413** on `*http.MaxBytesError` before anything spills to disk.
- **Slow-upload bound**: `ReadTimeout` (default 900s) + `ReadHeaderTimeout` (default 10s) on the `http.Server`, configurable via `INGRESS_HTTPREADTIMEOUT` / `INGRESS_HTTPREADHEADERTIMEOUT`.
- **Disk cap**: `sizeLimit` on the `/tmp` emptyDir + `ephemeral-storage` limits/requests in `clowdapp.yaml`.

## Tests

- Body over the request-body ceiling → 413, stager never called (MaxBytesReader path).
- Body above `DefaultMaxSize` but under a per-service `MaxSizeMap` ceiling → 202 staged.
- Existing 413 downstream size-check test still passes.

`make test` green.

[RHCLOUD-49841]: https://redhat.atlassian.net/browse/RHCLOUD-49841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ