### PR TITLE
fix(logging): hash x-rh-identity header on decode failure (RHCLOUD-49842)

### DIFF
--- a/cmd/insights-ingress/main.go
+++ b/cmd/insights-ingress/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
@@ -133,7 +135,12 @@ func main() {
 	)
 
 	identityErrorLogFunc := func(ctx context.Context, rawId, msg string) {
-		l.Log.WithFields(logrus.Fields{"error": msg, "rawId": rawId}).Error("Failed to decode Identity header")
+		// Never log the raw x-rh-identity header: even a header that fails to
+		// decode can carry PII (username, email, name, account number). Log a
+		// SHA-256 digest instead so identical bad headers stay correlatable
+		// without disclosing their contents to log readers (CWE-532).
+		digest := sha256.Sum256([]byte(rawId))
+		l.Log.WithFields(logrus.Fields{"error": msg, "rawIdSha256": hex.EncodeToString(digest[:])}).Error("Failed to decode Identity header")
 	}
 
 	var sub chi.Router = chi.NewRouter()


### PR DESCRIPTION
## Summary

`identityErrorLogFunc` logged the raw `x-rh-identity` header verbatim at ERROR level when `DecodeAndCheckIdentity` failed. Well-formed but policy-invalid headers (e.g. missing `org_id`/`type`) still carry PII (username, email, name, account number), which was persisted to CloudWatch unredacted.

Now logs a SHA-256 digest (`rawIdSha256`) of the raw header instead. Identical bad headers stay correlatable without disclosing contents to log readers.

## Ticket

[RHCLOUD-49842](https://redhat.atlassian.net/browse/RHCLOUD-49842) — CWE-532, FIND-003 in security audit.

## Notes

- Chose hash over truncation: truncating a base64 identity header can still expose leading PII bytes.
- Chose hash over error-type allowlist: simpler, zero-leak by construction, no dependency on middleware error taxonomy.

[RHCLOUD-49842]: https://redhat.atlassian.net/browse/RHCLOUD-49842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ