### PR TITLE
Add renovate packageRule for konflux-pipelines

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,13 @@
   "extends": [
     "github>RedHatInsights/konflux-pipelines//renovate/foreman_satellite/renovate.json"
   ],
+  "minimumConfidence": "high",
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["konflux-pipelines"],
+      "minimumConfidence": "neutral"
+    }
+  ],
   "tekton": {
     "schedule": [
       "at any time"


### PR DESCRIPTION
## Summary
- Adds `minimumConfidence: "high"` at the top level
- Adds a `packageRules` entry to set `minimumConfidence: "neutral"` for konflux-pipelines packages

This allows Renovate to process updates for konflux-pipelines packages even when confidence is not high, while maintaining high confidence requirements for all other packages.

Matches the configuration from https://github.com/RedHatInsights/payload-tracker-go/pull/571