### PR TITLE
feat: mark upload processing log entry as audit log

### DIFF
--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -323,7 +323,7 @@ func NewHandler(
 			Status:    "received",
 			StatusMsg: "Payload received by ingress",
 		}
-		requestLogger.Info("Payload received")
+		requestLogger.WithFields(logrus.Fields{"audit": true}).Info("Payload received")
 		tracker.Status(ps)
 
 		stageInput := &stage.Input{


### PR DESCRIPTION
## What?
Use "audit" field to mark the upload processing log entry as an audit log entry

## Why?
Will be used to validate the Splunk log forwarding feature (APPSRE-11704)

## How?
Added `audit: true` field to the logrus.Fields when logging "Payload received" message in the upload handler.

## Testing
Can be tested manually by uploading a payload and verifying the log entry contains the audit field.

## Anything Else?
This is a recreation of PR #499 to provide a fresh PR with updated changes.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation - No new input validation required
- [x] Output Encoding - No output encoding changes
- [x] Authentication and Password Management - No auth changes
- [x] Session Management - No session changes
- [x] Access Control - No access control changes
- [x] Cryptographic Practices - No crypto changes
- [x] Error Handling and Logging - Logging field addition only
- [x] Data Protection - No data protection changes
- [x] Communication Security - No communication changes
- [x] System Configuration - No config changes
- [x] Database Security - No database changes
- [x] File Management - No file management changes
- [x] Memory Management - No memory changes
- [x] General Coding Practices - Following existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)