### PR TITLE
Fix onprem tekton trigger to target master branch

### DIFF
--- a/.tekton/ingress-costmgmt-onprem-pull-request.yaml
+++ b/.tekton/ingress-costmgmt-onprem-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-onprem"
+      == "master"
     pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.73.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:

--- a/.tekton/ingress-costmgmt-onprem-push.yaml
+++ b/.tekton/ingress-costmgmt-onprem-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-onprem"
+      == "master"
     pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.73.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:


### PR DESCRIPTION
PR #778 set the `ingress-costmgmt-onprem` push and pull_request pipelines to trigger on `target_branch == "release-onprem"`, which does not exist in this repository, so the onprem build never triggers.

This points both onprem pipelines at `master`, matching the sibling `ingress-push`/`ingress-pull-request` pipelines and the original onprem onboarding branch (`konflux-ingress-costmgmt-onprem`).

No other changes — Dockerfile labels (incl. cpe override) and build-args (IMAGE_NAME/VERSION, hermetic, gomod prefetch, source-image) are already correct.